### PR TITLE
Pin swift-snapshot-testing, and added a test

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
       targets: ["Html"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", .revision("69b48c8")),
+    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "0.0.1")
   ],
   targets: [
     .target(

--- a/Tests/HtmlTests/AttributesTests.swift
+++ b/Tests/HtmlTests/AttributesTests.swift
@@ -14,6 +14,11 @@ final class AttributesTests: XCTestCase {
     XCTAssertEqual("<th scope=\"row\"/>", render(th([scope(.row)], [])))
     XCTAssertEqual("<th scope=\"rowgroup\"/>", render(th([scope(.rowgroup)], [])))
 
+    XCTAssertEqual(
+      "<a href=\"/user/foo&quot; onmouseover=&quot;alert(1)\">XSS</a>",
+      render(a([href("/user/foo\" onmouseover=\"alert(1)")], ["XSS"]))
+    )
+
     XCTAssertEqual("<a accesskey=\"a\"/>", render(a([accesskey("a")], [])))
 
     XCTAssertEqual(


### PR DESCRIPTION
### What

Turns out you can't have a dependency pinned to an exact version when that dependency has revision dependencies inside it. Should resolve #1 

Oh also, while chatting with Chris today I wanted to show that a certain type of escaping was working correctly so I wrote a test for it, and decided to keep it.