### PR TITLE
Pass attributes for base-64 images

### DIFF
--- a/Sources/Html/Elements.swift
+++ b/Sources/Html/Elements.swift
@@ -870,7 +870,7 @@ public func img(src: String, alt: String, _ attribs: [Attribute<Tag.Img>] = []) 
 public func img(base64: String, type: MediaType, alt: String, _ attribs: [Attribute<Tag.Img>])
   -> Node {
 
-    return img(src: "data:\(type.description);base64,\(base64)", alt: alt)
+    return img(src: "data:\(type.description);base64,\(base64)", alt: alt, attribs)
 }
 
 /// The `<input>` element represents a typed data field, usually with a form control to allow the user to edit the data.

--- a/Tests/HtmlTests/ElementsTests.swift
+++ b/Tests/HtmlTests/ElementsTests.swift
@@ -205,6 +205,13 @@ final class ElementsTests: XCTestCase {
 """,
       render(doc)
     )
+
+    XCTAssertEqual(
+      """
+<img src="data:image/png;base64,ZnVuY3Rpb25z" alt class="fun">
+""",
+      render(img(base64: "ZnVuY3Rpb25z", type: .image(.png), alt: "", [Html.class("fun")]))
+    )
   }
 }
 


### PR DESCRIPTION
Found this lil bug when updating the site to use swift-html. Wonder why Swift doesn't warn for unused arguments.