### PR TITLE
Add XcodeGen config + autogenerated Xcode project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,5 +69,4 @@ fastlane/test_output
 
 .DS_Store
 Packages/*
-*.xcodeproj/*
 Package.resolved

--- a/Html.xcodeproj/project.pbxproj
+++ b/Html.xcodeproj/project.pbxproj
@@ -1,0 +1,783 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		BF_00916079FF66FC0D646680666A7CD0E9 /* ElementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_31451D3CFCD7B04EC4D63F72F9128FC1 /* ElementsTests.swift */; };
+		BF_03A2EED843F90FA8E41B58C48D394F88 /* AttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_677B99ED8217F43EF3C12EA7E42E5E41 /* AttributesTests.swift */; };
+		BF_04DC74D1E8547CA689F92509E6688688 /* EventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_E4041CB4F38F966E11BD91C0AA6A5BFA /* EventsTests.swift */; };
+		BF_060C5A042E40BDCF757B2476C9391E9A /* AriaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_F75FACFFE0F0DA991D69CCC9C0698FEC /* AriaTests.swift */; };
+		BF_1601D2201CCCC901FF48A5EE027F86D1 /* Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_BC6D52A984AA8579A5E685CDB96DF92B /* Events.swift */; };
+		BF_1C9B40A0FC0ABC5FB5AB7C0DEB9648BD /* MediaTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_C83B72C4B65C28F6BE37D5682CA77D3A /* MediaTypeTests.swift */; };
+		BF_281A2C56D0B5DEAF6FF479602768DA21 /* Aria.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_1957C0F2CF49A306AA5402A17F204E13 /* Aria.swift */; };
+		BF_3D30C002A4DB359E1190590A0E06CF26 /* Html4.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_24FF729FC7DFE8D83700385CA1131573 /* Html4.swift */; };
+		BF_47AE237A21EB80E5615A255CABAE548D /* Aria.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_1957C0F2CF49A306AA5402A17F204E13 /* Aria.swift */; };
+		BF_49A551264360C1045B7CE1449A8A0F92 /* Render.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_9193E6DDB0F9A5361B5E2B130EC79A0C /* Render.swift */; };
+		BF_52C766E312455A9F21C4FE31F22E1DBA /* MediaTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_C83B72C4B65C28F6BE37D5682CA77D3A /* MediaTypeTests.swift */; };
+		BF_53549900846231225D3F60015E999C3C /* Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_BC6D52A984AA8579A5E685CDB96DF92B /* Events.swift */; };
+		BF_55BF1F4394531240992F88B1AC5449FE /* ElementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_31451D3CFCD7B04EC4D63F72F9128FC1 /* ElementsTests.swift */; };
+		BF_56E1E895F20B959BF2F4B380009EB538 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_11FBC77AD82B31BCEF6FB0320AC5E0DC /* Node.swift */; };
+		BF_57EC010E3B6C49C2849F73130B767F26 /* Html4.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_24FF729FC7DFE8D83700385CA1131573 /* Html4.swift */; };
+		BF_58E594B36913E4269F408F3FB239DC23 /* Html4.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_24FF729FC7DFE8D83700385CA1131573 /* Html4.swift */; };
+		BF_5B84B1D04E7CC3C24B53DD5C762880F0 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_8FDAFC3EFD6ADA13B065A1038F263092 /* XCTestManifests.swift */; };
+		BF_5F7A4CD92874E80A448E398686AB4A49 /* EventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_E4041CB4F38F966E11BD91C0AA6A5BFA /* EventsTests.swift */; };
+		BF_634B77774D529FB79D974CD92D1581B5 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_8FDAFC3EFD6ADA13B065A1038F263092 /* XCTestManifests.swift */; };
+		BF_6CD69795E5D3A3750C93421E7F6915F9 /* Attributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_04767826074DE160D5E92AA3059120FB /* Attributes.swift */; };
+		BF_70599033A05FAF611A84247D38429E6D /* Elements.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_94BD343165A56E15063E765F7DE8235A /* Elements.swift */; };
+		BF_7116AE49A0A02004E32A97BA5AFB3824 /* AttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_677B99ED8217F43EF3C12EA7E42E5E41 /* AttributesTests.swift */; };
+		BF_74EC162C08F3762ADF06A08E7C3CB9B2 /* Attributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_04767826074DE160D5E92AA3059120FB /* Attributes.swift */; };
+		BF_893F413F46D0747E482A79DA148794D7 /* MediaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_32E32CDF1C963D188F95E36B4147E862 /* MediaType.swift */; };
+		BF_8A813C2952374131A8EEB17D06FDD92B /* Attributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_04767826074DE160D5E92AA3059120FB /* Attributes.swift */; };
+		BF_8D6E09E24FD033CB991409C20A2A0A3D /* AttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_677B99ED8217F43EF3C12EA7E42E5E41 /* AttributesTests.swift */; };
+		BF_93F5343A37D75E1A9AA2CCEA5E3905A7 /* AriaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_F75FACFFE0F0DA991D69CCC9C0698FEC /* AriaTests.swift */; };
+		BF_A2248300D20A792C8162EB4A143A68F6 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_8FDAFC3EFD6ADA13B065A1038F263092 /* XCTestManifests.swift */; };
+		BF_B4F5881ED90EA5CC4E6F23E3FDF42201 /* MediaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_32E32CDF1C963D188F95E36B4147E862 /* MediaType.swift */; };
+		BF_C499570608EC754D1AC1F2A985C06979 /* Aria.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_1957C0F2CF49A306AA5402A17F204E13 /* Aria.swift */; };
+		BF_C6326FF838D957FC362C701E625C1626 /* MediaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_32E32CDF1C963D188F95E36B4147E862 /* MediaType.swift */; };
+		BF_D5D86DE26B8C00C74538D8E4EBEA2CE1 /* Render.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_9193E6DDB0F9A5361B5E2B130EC79A0C /* Render.swift */; };
+		BF_D7A3BAC594C6D8CA1E7C3B0031AA35D0 /* MediaTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_C83B72C4B65C28F6BE37D5682CA77D3A /* MediaTypeTests.swift */; };
+		BF_E0DCDF16D493E56E12C5C818E595A9CD /* Render.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_9193E6DDB0F9A5361B5E2B130EC79A0C /* Render.swift */; };
+		BF_E379B7325A4DB4D5B585FAE652CE48CC /* AriaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_F75FACFFE0F0DA991D69CCC9C0698FEC /* AriaTests.swift */; };
+		BF_E488C0FA800554500F1424D7928FBACB /* Elements.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_94BD343165A56E15063E765F7DE8235A /* Elements.swift */; };
+		BF_EDE4DEF484E3BBAD28E6227D79609B9B /* Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_BC6D52A984AA8579A5E685CDB96DF92B /* Events.swift */; };
+		BF_EE3C0B8D361573F2F2AA821BB1305FC4 /* ElementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_31451D3CFCD7B04EC4D63F72F9128FC1 /* ElementsTests.swift */; };
+		BF_F4A181DB92218A56A31339DB77401B9B /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_11FBC77AD82B31BCEF6FB0320AC5E0DC /* Node.swift */; };
+		BF_F635693DE5EE9E4EAF5CFED16527173F /* EventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_E4041CB4F38F966E11BD91C0AA6A5BFA /* EventsTests.swift */; };
+		BF_F642B02095C8E6A7AB2BACE484F2134F /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_11FBC77AD82B31BCEF6FB0320AC5E0DC /* Node.swift */; };
+		BF_FB38D7424CD1495955B9C7FEE7873E34 /* Elements.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_94BD343165A56E15063E765F7DE8235A /* Elements.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		CIP_BD4DB6ADD3C4AC046F4DB737AB53A171 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = P_71156FC3BAF7CC8140053AE66992A365 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = NT_0EC5D5A0415352CD656BDFBBA012F05F;
+			remoteInfo = HtmlTests_macOS;
+		};
+		CIP_CDDC2A09401C8099003115B2B9F92F7C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = P_71156FC3BAF7CC8140053AE66992A365 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = NT_C8AB64528B429FF8C5E983E839B1E0BE;
+			remoteInfo = HtmlTests_iOS;
+		};
+		CIP_F33D0C111B542229327595FB7EFA7550 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = P_71156FC3BAF7CC8140053AE66992A365 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = NT_E3FE8A7E649940DA2207FA60E84BE68D;
+			remoteInfo = HtmlTests_tvOS;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		FR_04767826074DE160D5E92AA3059120FB /* Attributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Attributes.swift; sourceTree = "<group>"; };
+		FR_11FBC77AD82B31BCEF6FB0320AC5E0DC /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
+		FR_137ABCB525F73E48E9E0329EC90064AF /* Html.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Html.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_186C495A13918FA9B6DC64977C0BEF84 /* HtmlTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HtmlTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_1957C0F2CF49A306AA5402A17F204E13 /* Aria.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Aria.swift; sourceTree = "<group>"; };
+		FR_24FF729FC7DFE8D83700385CA1131573 /* Html4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Html4.swift; sourceTree = "<group>"; };
+		FR_31451D3CFCD7B04EC4D63F72F9128FC1 /* ElementsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementsTests.swift; sourceTree = "<group>"; };
+		FR_32E32CDF1C963D188F95E36B4147E862 /* MediaType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaType.swift; sourceTree = "<group>"; };
+		FR_44D3298F923225BC3162818D9F543BBC /* HtmlTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HtmlTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_454B7862EFAF417284E587FDE4F417F7 /* Html.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Html.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_56BF69D04F58D631B62547910FBA29AB /* Html.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Html.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_677B99ED8217F43EF3C12EA7E42E5E41 /* AttributesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributesTests.swift; sourceTree = "<group>"; };
+		FR_87FEDF3B848906588C41DBE9A6F6E75E /* HtmlTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HtmlTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_8FDAFC3EFD6ADA13B065A1038F263092 /* XCTestManifests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
+		FR_9193E6DDB0F9A5361B5E2B130EC79A0C /* Render.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Render.swift; sourceTree = "<group>"; };
+		FR_94BD343165A56E15063E765F7DE8235A /* Elements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Elements.swift; sourceTree = "<group>"; };
+		FR_BC6D52A984AA8579A5E685CDB96DF92B /* Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Events.swift; sourceTree = "<group>"; };
+		FR_C83B72C4B65C28F6BE37D5682CA77D3A /* MediaTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTypeTests.swift; sourceTree = "<group>"; };
+		FR_E4041CB4F38F966E11BD91C0AA6A5BFA /* EventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsTests.swift; sourceTree = "<group>"; };
+		FR_F75FACFFE0F0DA991D69CCC9C0698FEC /* AriaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AriaTests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		G_0A21E25D6C83DF5311BDA1DD77A00B69 /* HtmlTests */ = {
+			isa = PBXGroup;
+			children = (
+				FR_F75FACFFE0F0DA991D69CCC9C0698FEC /* AriaTests.swift */,
+				FR_677B99ED8217F43EF3C12EA7E42E5E41 /* AttributesTests.swift */,
+				FR_31451D3CFCD7B04EC4D63F72F9128FC1 /* ElementsTests.swift */,
+				FR_E4041CB4F38F966E11BD91C0AA6A5BFA /* EventsTests.swift */,
+				FR_C83B72C4B65C28F6BE37D5682CA77D3A /* MediaTypeTests.swift */,
+				FR_8FDAFC3EFD6ADA13B065A1038F263092 /* XCTestManifests.swift */,
+			);
+			path = HtmlTests;
+			sourceTree = "<group>";
+		};
+		G_8F3F972CC52F24124E9996A4ABCD0256 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				FR_454B7862EFAF417284E587FDE4F417F7 /* Html.framework */,
+				FR_56BF69D04F58D631B62547910FBA29AB /* Html.framework */,
+				FR_137ABCB525F73E48E9E0329EC90064AF /* Html.framework */,
+				FR_186C495A13918FA9B6DC64977C0BEF84 /* HtmlTests.xctest */,
+				FR_44D3298F923225BC3162818D9F543BBC /* HtmlTests.xctest */,
+				FR_87FEDF3B848906588C41DBE9A6F6E75E /* HtmlTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		G_924F9EB02AD49D46C83BF2186833A14C /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				G_C3A94F08DFA6D454FF6B4D569840BC9B /* Html */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		G_B6EC796527F6FA1903AF2C18A2BFDA2D = {
+			isa = PBXGroup;
+			children = (
+				G_924F9EB02AD49D46C83BF2186833A14C /* Sources */,
+				G_D0C33AE703302B28824496412FDF9A0D /* Tests */,
+				G_8F3F972CC52F24124E9996A4ABCD0256 /* Products */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		G_C3A94F08DFA6D454FF6B4D569840BC9B /* Html */ = {
+			isa = PBXGroup;
+			children = (
+				FR_1957C0F2CF49A306AA5402A17F204E13 /* Aria.swift */,
+				FR_04767826074DE160D5E92AA3059120FB /* Attributes.swift */,
+				FR_94BD343165A56E15063E765F7DE8235A /* Elements.swift */,
+				FR_BC6D52A984AA8579A5E685CDB96DF92B /* Events.swift */,
+				FR_24FF729FC7DFE8D83700385CA1131573 /* Html4.swift */,
+				FR_32E32CDF1C963D188F95E36B4147E862 /* MediaType.swift */,
+				FR_11FBC77AD82B31BCEF6FB0320AC5E0DC /* Node.swift */,
+				FR_9193E6DDB0F9A5361B5E2B130EC79A0C /* Render.swift */,
+			);
+			path = Html;
+			sourceTree = "<group>";
+		};
+		G_D0C33AE703302B28824496412FDF9A0D /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				G_0A21E25D6C83DF5311BDA1DD77A00B69 /* HtmlTests */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		NT_0EC5D5A0415352CD656BDFBBA012F05F /* HtmlTests_macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_22C0E5C81ECB635472569EFFEA8319DA /* Build configuration list for PBXNativeTarget "HtmlTests_macOS" */;
+			buildPhases = (
+				SBP_BDBEA8231C20424E064DFB597FF52461 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				TD_30A3B330C6F053B8586D480DB12201CD /* PBXTargetDependency */,
+			);
+			name = HtmlTests_macOS;
+			productName = HtmlTests_macOS;
+			productReference = FR_44D3298F923225BC3162818D9F543BBC /* HtmlTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		NT_391C0E1A822D646F708827B001EB83D2 /* Html_iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_A4FAD437AF76FDBA9E3C49D474751D14 /* Build configuration list for PBXNativeTarget "Html_iOS" */;
+			buildPhases = (
+				SBP_2C92153816399A81B710EA9670C185ED /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Html_iOS;
+			productName = Html_iOS;
+			productReference = FR_454B7862EFAF417284E587FDE4F417F7 /* Html.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		NT_3DAB1392843626D3536CA19914B502C8 /* Html_macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_A5BF7EDA76AE6BC08855C7AC43201B90 /* Build configuration list for PBXNativeTarget "Html_macOS" */;
+			buildPhases = (
+				SBP_76E5A454BAA5945F6970AF64320FD788 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Html_macOS;
+			productName = Html_macOS;
+			productReference = FR_56BF69D04F58D631B62547910FBA29AB /* Html.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		NT_C8AB64528B429FF8C5E983E839B1E0BE /* HtmlTests_iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_2AAD18E374F68D92C2AF3F10876697CF /* Build configuration list for PBXNativeTarget "HtmlTests_iOS" */;
+			buildPhases = (
+				SBP_8B65B522274C0FC6C8C3436FB0CDF9A4 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				TD_CE87913632F6081A96430944DC96D750 /* PBXTargetDependency */,
+			);
+			name = HtmlTests_iOS;
+			productName = HtmlTests_iOS;
+			productReference = FR_186C495A13918FA9B6DC64977C0BEF84 /* HtmlTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		NT_E3DC39F33A9CC5CE33CBED0C7A0716AB /* Html_tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_1CD299291AE0BFFA37367999CEB6F900 /* Build configuration list for PBXNativeTarget "Html_tvOS" */;
+			buildPhases = (
+				SBP_02B92F45DAD4060A3E2D98ADBC952D28 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Html_tvOS;
+			productName = Html_tvOS;
+			productReference = FR_137ABCB525F73E48E9E0329EC90064AF /* Html.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		NT_E3FE8A7E649940DA2207FA60E84BE68D /* HtmlTests_tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_035E70787F58B7A45E9C0CA167594798 /* Build configuration list for PBXNativeTarget "HtmlTests_tvOS" */;
+			buildPhases = (
+				SBP_3B2888382ADFB09FB3468DEC2CB74839 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				TD_D9EDC92BB8D46CD2A5EE085DE157D229 /* PBXTargetDependency */,
+			);
+			name = HtmlTests_tvOS;
+			productName = HtmlTests_tvOS;
+			productReference = FR_87FEDF3B848906588C41DBE9A6F6E75E /* HtmlTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		P_71156FC3BAF7CC8140053AE66992A365 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1000;
+			};
+			buildConfigurationList = CL_728CA9104A9BA70AFD0D66631D9B25E2 /* Build configuration list for PBXProject "Html" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = G_B6EC796527F6FA1903AF2C18A2BFDA2D;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				NT_C8AB64528B429FF8C5E983E839B1E0BE /* HtmlTests_iOS */,
+				NT_0EC5D5A0415352CD656BDFBBA012F05F /* HtmlTests_macOS */,
+				NT_E3FE8A7E649940DA2207FA60E84BE68D /* HtmlTests_tvOS */,
+				NT_391C0E1A822D646F708827B001EB83D2 /* Html_iOS */,
+				NT_3DAB1392843626D3536CA19914B502C8 /* Html_macOS */,
+				NT_E3DC39F33A9CC5CE33CBED0C7A0716AB /* Html_tvOS */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		SBP_02B92F45DAD4060A3E2D98ADBC952D28 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_47AE237A21EB80E5615A255CABAE548D /* Aria.swift in Sources */,
+				BF_8A813C2952374131A8EEB17D06FDD92B /* Attributes.swift in Sources */,
+				BF_E488C0FA800554500F1424D7928FBACB /* Elements.swift in Sources */,
+				BF_53549900846231225D3F60015E999C3C /* Events.swift in Sources */,
+				BF_3D30C002A4DB359E1190590A0E06CF26 /* Html4.swift in Sources */,
+				BF_893F413F46D0747E482A79DA148794D7 /* MediaType.swift in Sources */,
+				BF_56E1E895F20B959BF2F4B380009EB538 /* Node.swift in Sources */,
+				BF_D5D86DE26B8C00C74538D8E4EBEA2CE1 /* Render.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_2C92153816399A81B710EA9670C185ED /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_281A2C56D0B5DEAF6FF479602768DA21 /* Aria.swift in Sources */,
+				BF_74EC162C08F3762ADF06A08E7C3CB9B2 /* Attributes.swift in Sources */,
+				BF_FB38D7424CD1495955B9C7FEE7873E34 /* Elements.swift in Sources */,
+				BF_1601D2201CCCC901FF48A5EE027F86D1 /* Events.swift in Sources */,
+				BF_57EC010E3B6C49C2849F73130B767F26 /* Html4.swift in Sources */,
+				BF_C6326FF838D957FC362C701E625C1626 /* MediaType.swift in Sources */,
+				BF_F642B02095C8E6A7AB2BACE484F2134F /* Node.swift in Sources */,
+				BF_E0DCDF16D493E56E12C5C818E595A9CD /* Render.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_3B2888382ADFB09FB3468DEC2CB74839 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_E379B7325A4DB4D5B585FAE652CE48CC /* AriaTests.swift in Sources */,
+				BF_03A2EED843F90FA8E41B58C48D394F88 /* AttributesTests.swift in Sources */,
+				BF_00916079FF66FC0D646680666A7CD0E9 /* ElementsTests.swift in Sources */,
+				BF_5F7A4CD92874E80A448E398686AB4A49 /* EventsTests.swift in Sources */,
+				BF_1C9B40A0FC0ABC5FB5AB7C0DEB9648BD /* MediaTypeTests.swift in Sources */,
+				BF_A2248300D20A792C8162EB4A143A68F6 /* XCTestManifests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_76E5A454BAA5945F6970AF64320FD788 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_C499570608EC754D1AC1F2A985C06979 /* Aria.swift in Sources */,
+				BF_6CD69795E5D3A3750C93421E7F6915F9 /* Attributes.swift in Sources */,
+				BF_70599033A05FAF611A84247D38429E6D /* Elements.swift in Sources */,
+				BF_EDE4DEF484E3BBAD28E6227D79609B9B /* Events.swift in Sources */,
+				BF_58E594B36913E4269F408F3FB239DC23 /* Html4.swift in Sources */,
+				BF_B4F5881ED90EA5CC4E6F23E3FDF42201 /* MediaType.swift in Sources */,
+				BF_F4A181DB92218A56A31339DB77401B9B /* Node.swift in Sources */,
+				BF_49A551264360C1045B7CE1449A8A0F92 /* Render.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_8B65B522274C0FC6C8C3436FB0CDF9A4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_060C5A042E40BDCF757B2476C9391E9A /* AriaTests.swift in Sources */,
+				BF_8D6E09E24FD033CB991409C20A2A0A3D /* AttributesTests.swift in Sources */,
+				BF_55BF1F4394531240992F88B1AC5449FE /* ElementsTests.swift in Sources */,
+				BF_F635693DE5EE9E4EAF5CFED16527173F /* EventsTests.swift in Sources */,
+				BF_D7A3BAC594C6D8CA1E7C3B0031AA35D0 /* MediaTypeTests.swift in Sources */,
+				BF_5B84B1D04E7CC3C24B53DD5C762880F0 /* XCTestManifests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_BDBEA8231C20424E064DFB597FF52461 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_93F5343A37D75E1A9AA2CCEA5E3905A7 /* AriaTests.swift in Sources */,
+				BF_7116AE49A0A02004E32A97BA5AFB3824 /* AttributesTests.swift in Sources */,
+				BF_EE3C0B8D361573F2F2AA821BB1305FC4 /* ElementsTests.swift in Sources */,
+				BF_04DC74D1E8547CA689F92509E6688688 /* EventsTests.swift in Sources */,
+				BF_52C766E312455A9F21C4FE31F22E1DBA /* MediaTypeTests.swift in Sources */,
+				BF_634B77774D529FB79D974CD92D1581B5 /* XCTestManifests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		TD_30A3B330C6F053B8586D480DB12201CD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = NT_0EC5D5A0415352CD656BDFBBA012F05F /* HtmlTests_macOS */;
+			targetProxy = CIP_BD4DB6ADD3C4AC046F4DB737AB53A171 /* PBXContainerItemProxy */;
+		};
+		TD_CE87913632F6081A96430944DC96D750 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = NT_C8AB64528B429FF8C5E983E839B1E0BE /* HtmlTests_iOS */;
+			targetProxy = CIP_CDDC2A09401C8099003115B2B9F92F7C /* PBXContainerItemProxy */;
+		};
+		TD_D9EDC92BB8D46CD2A5EE085DE157D229 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = NT_E3FE8A7E649940DA2207FA60E84BE68D /* HtmlTests_tvOS */;
+			targetProxy = CIP_F33D0C111B542229327595FB7EFA7550 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		BC_06DE2DAE0876989F3C0488B1CB0CB566 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlTests-macOS";
+				PRODUCT_NAME = HtmlTests;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		BC_0A3A17AA6DB74D83AA4F88F39E525D88 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlTests-iOS";
+				PRODUCT_NAME = HtmlTests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		BC_206415F1EA7AC68A380B7E00494C1223 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.Html-tvOS";
+				PRODUCT_NAME = Html;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		BC_2817927ED502C84B38368D2EC6B5EF32 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlTests-tvOS";
+				PRODUCT_NAME = HtmlTests;
+				SDKROOT = appletvos;
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = Debug;
+		};
+		BC_39241E7D98C62F1B3F9CA941C2CBCDCA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.Html-macOS";
+				PRODUCT_NAME = Html;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		BC_4218F41AE9912BC20AC6C66FE88BEF80 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlTests-tvOS";
+				PRODUCT_NAME = HtmlTests;
+				SDKROOT = appletvos;
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = Release;
+		};
+		BC_59DCA11BD298677A2C364B7091616443 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.Html-iOS";
+				PRODUCT_NAME = Html;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		BC_5D82526E135020393ADB819F6560D512 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.2;
+				TVOS_DEPLOYMENT_TARGET = 10.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		BC_6FFEDC49E6F0FCB2EA8AAA0BBAF3D946 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlTests-macOS";
+				PRODUCT_NAME = HtmlTests;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		BC_7E9F4DECB71DE8CC14B16B33F42E05EC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
+				TVOS_DEPLOYMENT_TARGET = 10.0;
+			};
+			name = Debug;
+		};
+		BC_9C34A53DEFE1DF0A68D267627509181A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.Html-iOS";
+				PRODUCT_NAME = Html;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		BC_B4AF93FC0F3F4AD627A2BFA37DF45866 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.Html-macOS";
+				PRODUCT_NAME = Html;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		BC_D7C8C3DFC45ADCC00EDD6185D1AC3B2B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlTests-iOS";
+				PRODUCT_NAME = HtmlTests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		BC_E34712B7075D6BB9AC2238F1A639D5B1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.Html-tvOS";
+				PRODUCT_NAME = Html;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		CL_035E70787F58B7A45E9C0CA167594798 /* Build configuration list for PBXNativeTarget "HtmlTests_tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_2817927ED502C84B38368D2EC6B5EF32 /* Debug */,
+				BC_4218F41AE9912BC20AC6C66FE88BEF80 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		CL_1CD299291AE0BFFA37367999CEB6F900 /* Build configuration list for PBXNativeTarget "Html_tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_206415F1EA7AC68A380B7E00494C1223 /* Debug */,
+				BC_E34712B7075D6BB9AC2238F1A639D5B1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		CL_22C0E5C81ECB635472569EFFEA8319DA /* Build configuration list for PBXNativeTarget "HtmlTests_macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_06DE2DAE0876989F3C0488B1CB0CB566 /* Debug */,
+				BC_6FFEDC49E6F0FCB2EA8AAA0BBAF3D946 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		CL_2AAD18E374F68D92C2AF3F10876697CF /* Build configuration list for PBXNativeTarget "HtmlTests_iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_0A3A17AA6DB74D83AA4F88F39E525D88 /* Debug */,
+				BC_D7C8C3DFC45ADCC00EDD6185D1AC3B2B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		CL_728CA9104A9BA70AFD0D66631D9B25E2 /* Build configuration list for PBXProject "Html" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_7E9F4DECB71DE8CC14B16B33F42E05EC /* Debug */,
+				BC_5D82526E135020393ADB819F6560D512 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		CL_A4FAD437AF76FDBA9E3C49D474751D14 /* Build configuration list for PBXNativeTarget "Html_iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_9C34A53DEFE1DF0A68D267627509181A /* Debug */,
+				BC_59DCA11BD298677A2C364B7091616443 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		CL_A5BF7EDA76AE6BC08855C7AC43201B90 /* Build configuration list for PBXNativeTarget "Html_macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_39241E7D98C62F1B3F9CA941C2CBCDCA /* Debug */,
+				BC_B4AF93FC0F3F4AD627A2BFA37DF45866 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = P_71156FC3BAF7CC8140053AE66992A365 /* Project object */;
+}

--- a/Html.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Html.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Html.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Html.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Html.xcodeproj/xcshareddata/xcschemes/Html_iOS.xcscheme
+++ b/Html.xcodeproj/xcshareddata/xcschemes/Html_iOS.xcscheme
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1000"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NT_391C0E1A822D646F708827B001EB83D2"
+               BuildableName = "Html.framework"
+               BlueprintName = "Html_iOS"
+               ReferencedContainer = "container:Html.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NT_C8AB64528B429FF8C5E983E839B1E0BE"
+               BuildableName = "HtmlTests.xctest"
+               BlueprintName = "HtmlTests_iOS"
+               ReferencedContainer = "container:Html.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "NT_391C0E1A822D646F708827B001EB83D2"
+            BuildableName = "Html.framework"
+            BlueprintName = "Html_iOS"
+            ReferencedContainer = "container:Html.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+      </CommandLineArguments>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "NT_391C0E1A822D646F708827B001EB83D2"
+            BuildableName = "Html.framework"
+            BlueprintName = "Html_iOS"
+            ReferencedContainer = "container:Html.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+      </CommandLineArguments>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "NT_391C0E1A822D646F708827B001EB83D2"
+            BuildableName = "Html.framework"
+            BlueprintName = "Html_iOS"
+            ReferencedContainer = "container:Html.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Html.xcodeproj/xcshareddata/xcschemes/Html_macOS.xcscheme
+++ b/Html.xcodeproj/xcshareddata/xcschemes/Html_macOS.xcscheme
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1000"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NT_3DAB1392843626D3536CA19914B502C8"
+               BuildableName = "Html.framework"
+               BlueprintName = "Html_macOS"
+               ReferencedContainer = "container:Html.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NT_0EC5D5A0415352CD656BDFBBA012F05F"
+               BuildableName = "HtmlTests.xctest"
+               BlueprintName = "HtmlTests_macOS"
+               ReferencedContainer = "container:Html.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "NT_3DAB1392843626D3536CA19914B502C8"
+            BuildableName = "Html.framework"
+            BlueprintName = "Html_macOS"
+            ReferencedContainer = "container:Html.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+      </CommandLineArguments>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "NT_3DAB1392843626D3536CA19914B502C8"
+            BuildableName = "Html.framework"
+            BlueprintName = "Html_macOS"
+            ReferencedContainer = "container:Html.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+      </CommandLineArguments>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "NT_3DAB1392843626D3536CA19914B502C8"
+            BuildableName = "Html.framework"
+            BlueprintName = "Html_macOS"
+            ReferencedContainer = "container:Html.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Html.xcodeproj/xcshareddata/xcschemes/Html_tvOS.xcscheme
+++ b/Html.xcodeproj/xcshareddata/xcschemes/Html_tvOS.xcscheme
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1000"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NT_E3DC39F33A9CC5CE33CBED0C7A0716AB"
+               BuildableName = "Html.framework"
+               BlueprintName = "Html_tvOS"
+               ReferencedContainer = "container:Html.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NT_E3FE8A7E649940DA2207FA60E84BE68D"
+               BuildableName = "HtmlTests.xctest"
+               BlueprintName = "HtmlTests_tvOS"
+               ReferencedContainer = "container:Html.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "NT_E3DC39F33A9CC5CE33CBED0C7A0716AB"
+            BuildableName = "Html.framework"
+            BlueprintName = "Html_tvOS"
+            ReferencedContainer = "container:Html.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+      </CommandLineArguments>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "NT_E3DC39F33A9CC5CE33CBED0C7A0716AB"
+            BuildableName = "Html.framework"
+            BlueprintName = "Html_tvOS"
+            ReferencedContainer = "container:Html.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+      </CommandLineArguments>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "NT_E3DC39F33A9CC5CE33CBED0C7A0716AB"
+            BuildableName = "Html.framework"
+            BlueprintName = "Html_tvOS"
+            ReferencedContainer = "container:Html.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/project.yml
+++ b/project.yml
@@ -1,0 +1,27 @@
+name: Html
+options:
+  bundleIdPrefix: co.pointfree
+  deploymentTarget:
+    iOS: 10.0
+    macOS: '10.10'
+    tvOS: 10.0
+  indentWidth: 2
+  tabWidth: 2
+  usesTabs: false
+targets:
+  Html:
+    platform: [macOS, iOS, tvOS]
+    settings:
+      FRAMEWORK_SEARCH_PATHS: $(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks
+    scheme:
+      testTargets: [HtmlTests_$platform]
+    sources: [Sources]
+    type: framework
+  HtmlTests:
+    dependencies: [{target: HtmlTests_$platform}]
+    platform: [macOS, iOS, tvOS]
+    sources:
+      - path: Tests
+        excludes:
+          - LinuxMain.swift
+    type: bundle.unit-test


### PR DESCRIPTION
This adds an Xcode project to the repo to improve Carthage support out of the box, see #17. I have simply taken [the sample XcodeGen config from swift-snapshot-testing](https://github.com/pointfreeco/swift-snapshot-testing/blob/master/project.yml) and tweaked what looked like it needed tweaking.

I am just not sure about the Deployment Target settings. Currently I have let them at this:

```yml
deploymentTarget:
  iOS: 10.0
  macOS: '10.10'
  tvOS: 10.0
```

I have tried the result using Carthage and the framework builds, so it looks fine. Would it make sense to try and build the framework using the Xcode project file _in the CI build_ to make sure it stays operational?

PS. I have also removed the `xcodeproj` pattern from `.gitignore`.