### PR TITLE
Update Makefile: use XcodeGen instead of SPM to create .xcodeproj

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test-ios: xcodeproj
 linux-main:
 	swift test --generate-linuxmain
 
-test-swift: xcodeproj
+test-swift:
 	swift test --generate-linuxmain \
 	  && swift test
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 xcodeproj:
-	swift package generate-xcodeproj
+	@command -v xcodegen >/dev/null 2>&1 || { echo >&2 "Required tool missing: XcodeGen. Try 'brew install xcodegen' perhaps?"; exit 1; }
+	xcodegen
 
 test-linux:
 	docker build --tag html . \


### PR DESCRIPTION
In #18 I forgot to update the Makefile, so that running `make xcodeproj` would still use SPM to generate the Xcode project file. Not what we want.