### PR TITLE
Release 0.2.0

### DIFF
--- a/Html.podspec
+++ b/Html.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "Html"
-  s.version = "0.1.3"
+  s.version = "0.2.0"
   s.summary = "A Swift DSL for type-safe, extensible, and transformable HTML documents."
 
   s.description = <<-DESC

--- a/HtmlSnapshotTesting.podspec
+++ b/HtmlSnapshotTesting.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "HtmlSnapshotTesting"
-  s.version = "0.1.3"
+  s.version = "0.2.0"
   s.summary = "SnapshotTesting strategies for Html."
 
   s.description = <<-DESC
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.10"
   s.tvos.deployment_target = "10.0"
 
-  s.dependency "Html", "~> 0.1"
+  s.dependency "Html", "~> 0.2"
   s.dependency "SnapshotTesting", "~> 1.1"
 
   s.source_files = "Sources/HtmlSnapshotTesting/**/*.swift"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The popular choice for rendering HTML in Swift these days is to use templating l
 
 HTML documents can be created in a tree-like fashion, much like you might create a nested JSON document:
 
-```swift 
+```swift
 import Html
 
 let document = html([
@@ -189,7 +189,7 @@ There are a few reasons you might want to still use a templating language:
 If you use [Carthage](https://github.com/Carthage/Carthage), you can add the following dependency to your `Cartfile`:
 
 ``` ruby
-github "pointfreeco/swift-html" ~> 0.1.3
+github "pointfreeco/swift-html" ~> 0.2
 ```
 
 ### CocoaPods
@@ -197,7 +197,7 @@ github "pointfreeco/swift-html" ~> 0.1.3
 If your project uses [CocoaPods](https://cocoapods.org), just add the following to your `Podfile`:
 
 ``` ruby
-pod 'Html', '~> 0.1.3'
+pod 'Html', '~> 0.2'
 ```
 
 ### SwiftPM
@@ -206,9 +206,11 @@ If you want to use swift-html in a project that uses [SwiftPM](https://swift.org
 
 ``` swift
 dependencies: [
-  .package(url: "https://github.com/pointfreeco/swift-html.git", from: "0.1.3")
+  .package(url: "https://github.com/pointfreeco/swift-html.git", from: "0.2.0")
 ]
 ```
+
+From there you can add `Html` or `HtmlSnapshotTesting` as target dependencies.
 
 ### Xcode Sub-project
 


### PR DESCRIPTION
## What's new?

- Support for Carthage and CocoaPods
- A brand new module, `HtmlSnapshotTesting` for testing your HTML using [SnapshotTesting](https://github.com/pointfreeco/swift-snapshot-testing)
- A new `debugRender` function, which renders HTML with human-readable indentation
- Support for iOS, tvOS, and watchOS
- Added a missing `style(unsafe:)` attribute helper that takes non-static strings
- Added a missing `enctype` form attribute helper

## What's fixed?

- Fixed `thead` and `tbody` element helpers to require nesting in a `table`