### PR TITLE
Removed redundant 'indirect' modifier on Node

### DIFF
--- a/Sources/Html/Node.swift
+++ b/Sources/Html/Node.swift
@@ -7,7 +7,7 @@ public enum Node {
   case doctype(String)
 
   /// Represents an element node with a tag name, an array of attributes, and an array of child nodes.
-  indirect case element(String, [(key: String, value: String?)], [Node])
+  case element(String, [(key: String, value: String?)], [Node])
 
   /// An unsafe escape hatch: represents raw text that should not be escaped by a renderer.
   case raw(String)


### PR DESCRIPTION
Using Array (in this case) or any other"naturally indirect" storage makes said modifier no longer necessary in an enum.

This PR is just that. I don't actually know if behind the scenes the Swift compiler was able to understand that it didn't need to indirectly reference the incriminated `case` or not, so this change may even be good in term of the lib's speed.