### PR TITLE
Fix summary and legend tags

### DIFF
--- a/Sources/Html/ChildOf.swift
+++ b/Sources/Html/ChildOf.swift
@@ -54,17 +54,6 @@ extension ChildOf where Element == Tag.Colgroup {
   }
 }
 
-extension ChildOf where Element == Tag.Details {
-  /// The first `<summary>` child element of a `<details>` element represents a summary, caption, or legend for the rest of the contents of the parent `<details>` element, if any.
-  ///
-  /// - Parameters:
-  ///   - attributes: Attributes.
-  ///   - content: Child nodes.
-  public static func summary(attributes: [Attribute<Tag.Summary>] = [], _ content: Node...) -> ChildOf {
-    return .init(.element("summary", attributes: attributes, .fragment(content)))
-  }
-}
-
 extension ChildOf where Element == Tag.Dl {
   /// The `<dd>` element represents a description, part of a term-description group in a description list (`<dl>` element).
   ///
@@ -82,17 +71,6 @@ extension ChildOf where Element == Tag.Dl {
   ///   - content: Child nodes.
   public static func dt(attributes: [Attribute<Tag.Dt>] = [], _ content: Node...) -> ChildOf {
     return .init(.element("dt", attributes: attributes, .fragment(content)))
-  }
-}
-
-extension ChildOf where Element == Tag.Fieldset {
-  /// The `<legend>` element represents a caption for the rest of the contents of the `<legend>` element's parent `<fieldset>` element, if any.
-  ///
-  /// - Parameters:
-  ///   - attributes: Attributes.
-  ///   - content: Child nodes.
-  public static func legend(attributes: [Attribute<Tag.Legend>] = [], _ content: Node...) -> ChildOf {
-    return .init(.element("legend", attributes: attributes, .fragment(content)))
   }
 }
 

--- a/Sources/Html/ChildOf.swift
+++ b/Sources/Html/ChildOf.swift
@@ -54,6 +54,17 @@ extension ChildOf where Element == Tag.Colgroup {
   }
 }
 
+extension ChildOf where Element == Tag.Details {
+  /// The first `<summary>` child element of a `<details>` element represents a summary, caption, or legend for the rest of the contents of the parent `<details>` element, if any.
+  ///
+  /// - Parameters:
+  ///   - attributes: Attributes.
+  ///   - content: Child nodes.
+  public static func summary(attributes: [Attribute<Tag.Summary>] = [], _ content: Node...) -> ChildOf {
+    return .init(.element("summary", attributes: attributes, .fragment(content)))
+  }
+}
+
 extension ChildOf where Element == Tag.Dl {
   /// The `<dd>` element represents a description, part of a term-description group in a description list (`<dl>` element).
   ///
@@ -71,6 +82,17 @@ extension ChildOf where Element == Tag.Dl {
   ///   - content: Child nodes.
   public static func dt(attributes: [Attribute<Tag.Dt>] = [], _ content: Node...) -> ChildOf {
     return .init(.element("dt", attributes: attributes, .fragment(content)))
+  }
+}
+
+extension ChildOf where Element == Tag.Fieldset {
+  /// The `<legend>` element represents a caption for the rest of the contents of the `<legend>` element's parent `<fieldset>` element, if any.
+  ///
+  /// - Parameters:
+  ///   - attributes: Attributes.
+  ///   - content: Child nodes.
+  public static func legend(attributes: [Attribute<Tag.Legend>] = [], _ content: Node...) -> ChildOf {
+    return .init(.element("legend", attributes: attributes, .fragment(content)))
   }
 }
 

--- a/Sources/Html/Elements.swift
+++ b/Sources/Html/Elements.swift
@@ -157,13 +157,15 @@ extension Node {
     return .element("del", attributes: attributes, .fragment(content))
   }
 
-  // TODO: required first child element "summary"
   /// The `<details>` element represents a disclosure widget from which the user can obtain additional information or controls.
   ///
   /// - Parameters:
   ///   - attributes: Attributes.
   ///   - content: Child nodes.
-  public static func details(attributes: [Attribute<Tag.Details>] = [], _ content: Node...) -> Node {
+  public static func details(
+    attributes: [Attribute<Tag.Details>] = [],
+    _ content: Node...
+    ) -> Node {
     return .element("details", attributes: attributes, .fragment(content))
   }
 
@@ -430,6 +432,15 @@ extension Node {
     return .element("label", attributes: attributes, .fragment(content))
   }
 
+  /// The `<legend>` element represents a caption for the rest of the contents of the `<legend>` element's parent `<fieldset>` element, if any.
+  ///
+  /// - Parameters:
+  ///   - attributes: Attributes.
+  ///   - content: Child nodes.
+  public static func legend(attributes: [Attribute<Tag.Legend>] = [], _ content: Node...) -> Node {
+    return .element("legend", attributes: attributes, .fragment(content))
+  }
+
   /// The `<main>` element represents the main content of the `<body>` of a document or application.
   ///
   /// - Parameters:
@@ -661,6 +672,15 @@ extension Node {
   ///   - content: Child nodes.
   public static func sub(attributes: [Attribute<Tag.Sub>] = [], _ content: Node...) -> Node {
     return .element("sub", attributes: attributes, .fragment(content))
+  }
+
+  /// The first `<summary>` child element of a `<details>` element represents a summary, caption, or legend for the rest of the contents of the parent `<details>` element, if any.
+  ///
+  /// - Parameters:
+  ///   - attributes: Attributes.
+  ///   - content: Child nodes.
+  public static func summary(attributes: [Attribute<Tag.Summary>] = [], _ content: Node...) -> Node {
+    return .element("summary", attributes: attributes, .fragment(content))
   }
 
   /// The `<sup>` element represents a superscript.

--- a/Sources/Html/Elements.swift
+++ b/Sources/Html/Elements.swift
@@ -161,12 +161,16 @@ extension Node {
   ///
   /// - Parameters:
   ///   - attributes: Attributes.
+  ///   - summary: A summary.
   ///   - content: Child nodes.
   public static func details(
     attributes: [Attribute<Tag.Details>] = [],
+    _ summary: ChildOf<Tag.Details>? = nil,
     _ content: Node...
-    ) -> Node {
-    return .element("details", attributes: attributes, .fragment(content))
+    )
+    -> Node {
+
+      return .element("details", attributes: attributes, summary.map { $0.rawValue } ?? [], .fragment(content))
   }
 
   /// The `<dfn>` element represents the defining instance of a term. The term-description group, `<p>`, `<li>` or `<section>` element that is the nearest ancestor of the `<dfn>` element must also contain the definition(s) for the term given by the `<dfn>` element.
@@ -216,9 +220,16 @@ extension Node {
   ///
   /// - Parameters:
   ///   - attributes: Attributes.
+  ///   - legend: A legend.
   ///   - content: Child nodes.
-  public static func fieldset(attributes: [Attribute<Tag.Fieldset>] = [], _ content: Node...) -> Node {
-    return .element("fieldset", attributes: attributes, .fragment(content))
+  public static func fieldset(
+    attributes: [Attribute<Tag.Fieldset>] = [],
+    _ legend: ChildOf<Tag.Fieldset>? = nil,
+    _ content: Node...
+    )
+    -> Node {
+
+      return .element("fieldset", attributes: attributes, legend.map { $0.rawValue } ?? [], .fragment(content))
   }
 
   /// The `<figure>` element represents some flow content, optionally with a caption, that is self-contained (like a complete sentence) and is typically referenced as a single unit from the main flow of the document.
@@ -430,15 +441,6 @@ extension Node {
   ///   - content: Child nodes.
   public static func label(attributes: [Attribute<Tag.Label>] = [], _ content: Node...) -> Node {
     return .element("label", attributes: attributes, .fragment(content))
-  }
-
-  /// The `<legend>` element represents a caption for the rest of the contents of the `<legend>` element's parent `<fieldset>` element, if any.
-  ///
-  /// - Parameters:
-  ///   - attributes: Attributes.
-  ///   - content: Child nodes.
-  public static func legend(attributes: [Attribute<Tag.Legend>] = [], _ content: Node...) -> Node {
-    return .element("legend", attributes: attributes, .fragment(content))
   }
 
   /// The `<main>` element represents the main content of the `<body>` of a document or application.
@@ -672,15 +674,6 @@ extension Node {
   ///   - content: Child nodes.
   public static func sub(attributes: [Attribute<Tag.Sub>] = [], _ content: Node...) -> Node {
     return .element("sub", attributes: attributes, .fragment(content))
-  }
-
-  /// The first `<summary>` child element of a `<details>` element represents a summary, caption, or legend for the rest of the contents of the parent `<details>` element, if any.
-  ///
-  /// - Parameters:
-  ///   - attributes: Attributes.
-  ///   - content: Child nodes.
-  public static func summary(attributes: [Attribute<Tag.Summary>] = [], _ content: Node...) -> Node {
-    return .element("summary", attributes: attributes, .fragment(content))
   }
 
   /// The `<sup>` element represents a superscript.

--- a/Sources/Html/Elements.swift
+++ b/Sources/Html/Elements.swift
@@ -165,12 +165,26 @@ extension Node {
   ///   - content: Child nodes.
   public static func details(
     attributes: [Attribute<Tag.Details>] = [],
-    _ summary: ChildOf<Tag.Details>? = nil,
+    _ summary: ChildOf<Tag.Details>,
     _ content: Node...
     )
     -> Node {
 
-      return .element("details", attributes: attributes, summary.map { $0.rawValue } ?? [], .fragment(content))
+      return details(attributes: attributes, summary.rawValue, .fragment(content))
+  }
+
+  /// The `<details>` element represents a disclosure widget from which the user can obtain additional information or controls.
+  ///
+  /// - Parameters:
+  ///   - attributes: Attributes.
+  ///   - content: Child nodes.
+  public static func details(
+    attributes: [Attribute<Tag.Details>] = [],
+    _ content: Node...
+    )
+    -> Node {
+
+      return .element("details", attributes: attributes, .fragment(content))
   }
 
   /// The `<dfn>` element represents the defining instance of a term. The term-description group, `<p>`, `<li>` or `<section>` element that is the nearest ancestor of the `<dfn>` element must also contain the definition(s) for the term given by the `<dfn>` element.
@@ -224,12 +238,26 @@ extension Node {
   ///   - content: Child nodes.
   public static func fieldset(
     attributes: [Attribute<Tag.Fieldset>] = [],
-    _ legend: ChildOf<Tag.Fieldset>? = nil,
+    _ legend: ChildOf<Tag.Fieldset>,
     _ content: Node...
     )
     -> Node {
 
-      return .element("fieldset", attributes: attributes, legend.map { $0.rawValue } ?? [], .fragment(content))
+      return .fieldset(attributes: attributes, legend.rawValue, .fragment(content))
+  }
+
+  /// The `<fieldset>` element represents a set of form controls optionally grouped under a common name.
+  ///
+  /// - Parameters:
+  ///   - attributes: Attributes.
+  ///   - content: Child nodes.
+  public static func fieldset(
+    attributes: [Attribute<Tag.Fieldset>] = [],
+    _ content: Node...
+    )
+    -> Node {
+
+      return .element("fieldset", attributes: attributes, .fragment(content))
   }
 
   /// The `<figure>` element represents some flow content, optionally with a caption, that is self-contained (like a complete sentence) and is typically referenced as a single unit from the main flow of the document.

--- a/Tests/HtmlSnapshotTestingTests/HtmlSnapshotTestingTests.swift
+++ b/Tests/HtmlSnapshotTestingTests/HtmlSnapshotTestingTests.swift
@@ -448,6 +448,9 @@ final class SnapshotTestingTests: SnapshotTestCase {
       .details(
         .summary()
       ),
+      .details(
+        .div()
+      ),
       .dfn(),
       .div(),
       .dl(
@@ -459,6 +462,9 @@ final class SnapshotTestingTests: SnapshotTestCase {
       .fieldset(),
       .fieldset(
         .legend()
+      ),
+      .fieldset(
+        .div()
       ),
       .figure(
         .figcaption()

--- a/Tests/HtmlSnapshotTestingTests/HtmlSnapshotTestingTests.swift
+++ b/Tests/HtmlSnapshotTestingTests/HtmlSnapshotTestingTests.swift
@@ -444,6 +444,7 @@ final class SnapshotTestingTests: SnapshotTestCase {
       .cite(),
       .code(),
       .del(),
+      .details(),
       .details(
         .summary()
       ),
@@ -455,6 +456,7 @@ final class SnapshotTestingTests: SnapshotTestCase {
       ),
       .em(),
       .embed(),
+      .fieldset(),
       .fieldset(
         .legend()
       ),

--- a/Tests/HtmlSnapshotTestingTests/HtmlSnapshotTestingTests.swift
+++ b/Tests/HtmlSnapshotTestingTests/HtmlSnapshotTestingTests.swift
@@ -449,6 +449,10 @@ final class SnapshotTestingTests: SnapshotTestCase {
         .summary()
       ),
       .details(
+        .summary(),
+        .div()
+      ),
+      .details(
         .div()
       ),
       .dfn(),
@@ -462,6 +466,10 @@ final class SnapshotTestingTests: SnapshotTestCase {
       .fieldset(),
       .fieldset(
         .legend()
+      ),
+      .fieldset(
+        .legend(),
+        .div()
       ),
       .fieldset(
         .div()

--- a/Tests/HtmlSnapshotTestingTests/HtmlSnapshotTestingTests.swift
+++ b/Tests/HtmlSnapshotTestingTests/HtmlSnapshotTestingTests.swift
@@ -445,8 +445,7 @@ final class SnapshotTestingTests: SnapshotTestCase {
       .code(),
       .del(),
       .details(
-// TODO: `summary` returns ChildOf<FieldSet> but `details` only wants Node. is that correct?
-//        .summary(),
+        .summary()
       ),
       .dfn(),
       .div(),
@@ -457,8 +456,7 @@ final class SnapshotTestingTests: SnapshotTestCase {
       .em(),
       .embed(),
       .fieldset(
-// TODO: `legend` returns ChildOf<FieldSet> but `fieldset` only wants Node. is that correct?
-//        .legend(),
+        .legend()
       ),
       .figure(
         .figcaption()

--- a/Tests/HtmlSnapshotTestingTests/XCTestManifests.swift
+++ b/Tests/HtmlSnapshotTestingTests/XCTestManifests.swift
@@ -1,16 +1,16 @@
 import XCTest
 
 extension SnapshotTestingTests {
-    static let __allTests = [
-        ("testComplexHtml", testComplexHtml),
-        ("testSnapshots", testSnapshots),
+  static let __allTests = [
+    ("testComplexHtml", testComplexHtml),
+    ("testSnapshots", testSnapshots),
     ]
 }
 
-#if !os(macOS)
+#if os(Linux)
 public func __allTests() -> [XCTestCaseEntry] {
-    return [
-        testCase(SnapshotTestingTests.__allTests),
-    ]
+  return [
+    testCase(SnapshotTestingTests.__allTests),
+  ]
 }
 #endif

--- a/Tests/HtmlSnapshotTestingTests/__Snapshots__/HtmlSnapshotTestingTests/testSnapshots.1.html
+++ b/Tests/HtmlSnapshotTestingTests/__Snapshots__/HtmlSnapshotTestingTests/testSnapshots.1.html
@@ -42,6 +42,12 @@
   </summary>
 </details>
 <details>
+  <summary>
+  </summary>
+  <div>
+  </div>
+</details>
+<details>
   <div>
   </div>
 </details>
@@ -63,6 +69,12 @@
 <fieldset>
   <legend>
   </legend>
+</fieldset>
+<fieldset>
+  <legend>
+  </legend>
+  <div>
+  </div>
 </fieldset>
 <fieldset>
   <div>

--- a/Tests/HtmlSnapshotTestingTests/__Snapshots__/HtmlSnapshotTestingTests/testSnapshots.1.html
+++ b/Tests/HtmlSnapshotTestingTests/__Snapshots__/HtmlSnapshotTestingTests/testSnapshots.1.html
@@ -36,6 +36,8 @@
 <del>
 </del>
 <details>
+</details>
+<details>
   <summary>
   </summary>
 </details>
@@ -52,6 +54,8 @@
 <em>
 </em>
 <embed>
+<fieldset>
+</fieldset>
 <fieldset>
   <legend>
   </legend>

--- a/Tests/HtmlSnapshotTestingTests/__Snapshots__/HtmlSnapshotTestingTests/testSnapshots.1.html
+++ b/Tests/HtmlSnapshotTestingTests/__Snapshots__/HtmlSnapshotTestingTests/testSnapshots.1.html
@@ -36,6 +36,8 @@
 <del>
 </del>
 <details>
+  <summary>
+  </summary>
 </details>
 <dfn>
 </dfn>
@@ -51,6 +53,8 @@
 </em>
 <embed>
 <fieldset>
+  <legend>
+  </legend>
 </fieldset>
 <figure>
   <figcaption>

--- a/Tests/HtmlSnapshotTestingTests/__Snapshots__/HtmlSnapshotTestingTests/testSnapshots.1.html
+++ b/Tests/HtmlSnapshotTestingTests/__Snapshots__/HtmlSnapshotTestingTests/testSnapshots.1.html
@@ -41,6 +41,10 @@
   <summary>
   </summary>
 </details>
+<details>
+  <div>
+  </div>
+</details>
 <dfn>
 </dfn>
 <div>
@@ -59,6 +63,10 @@
 <fieldset>
   <legend>
   </legend>
+</fieldset>
+<fieldset>
+  <div>
+  </div>
 </fieldset>
 <figure>
   <figcaption>

--- a/Tests/HtmlTests/XCTestManifests.swift
+++ b/Tests/HtmlTests/XCTestManifests.swift
@@ -1,43 +1,43 @@
 import XCTest
 
 extension AriaTests {
-    static let __allTests = [
-        ("testAriaAttributes", testAriaAttributes),
+  static let __allTests = [
+    ("testAriaAttributes", testAriaAttributes),
     ]
 }
 
 extension AttributesTests {
-    static let __allTests = [
-        ("testAttributes", testAttributes),
+  static let __allTests = [
+    ("testAttributes", testAttributes),
     ]
 }
 
 extension ElementsTests {
-    static let __allTests = [
-        ("testBase64Snapshot", testBase64Snapshot),
+  static let __allTests = [
+    ("testBase64Snapshot", testBase64Snapshot),
     ]
 }
 
 extension EventsTests {
-    static let __allTests = [
-        ("testEventsSnapshot", testEventsSnapshot),
+  static let __allTests = [
+    ("testEventsSnapshot", testEventsSnapshot),
     ]
 }
 
 extension MediaTypeTests {
-    static let __allTests = [
-        ("testMediaType", testMediaType),
+  static let __allTests = [
+    ("testMediaType", testMediaType),
     ]
 }
 
-#if !os(macOS)
+#if os(Linux)
 public func __allTests() -> [XCTestCaseEntry] {
-    return [
-        testCase(AriaTests.__allTests),
-        testCase(AttributesTests.__allTests),
-        testCase(ElementsTests.__allTests),
-        testCase(EventsTests.__allTests),
-        testCase(MediaTypeTests.__allTests),
-    ]
+  return [
+    testCase(AriaTests.__allTests),
+    testCase(AttributesTests.__allTests),
+    testCase(ElementsTests.__allTests),
+    testCase(EventsTests.__allTests),
+    testCase(MediaTypeTests.__allTests),
+  ]
 }
 #endif


### PR DESCRIPTION
Both `summary` and `legend` must be the first element of `details` and `fieldset` accordingly, but `details` and `fieldset` can take any node afterwards—because of this they took `Node` but we encoded `summary` and `legend` using `ChildOf` semantics, maybe them basically unusable. This adds a single `ChildOf` argument in an overload to preserve the semantics in the type system and fix the bug.