### PR TITLE
Make xcodegen a Package.swift dependency.

### DIFF
--- a/Html.xcodeproj/project.pbxproj
+++ b/Html.xcodeproj/project.pbxproj
@@ -3,256 +3,256 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		BF_008A5702F99F07846B812AF73C8B45E1 /* Html4.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_84247EDD4C722F051D26423EAF9556B4 /* Html4.swift */; };
-		BF_04EAFBA677DF1516B69B3E94C510B122 /* HtmlSnapshotTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_2C04ED2D80670BFA8174C411C3DCC50B /* HtmlSnapshotTesting.swift */; };
-		BF_050A434EB48E3A85149CA2DC1947E934 /* ChildOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_40794F1143674CDA249455CEE44CF36F /* ChildOf.swift */; };
-		BF_058AE1B1A3D7CFF10D12F6161A5BB5D5 /* ElementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_AF1B21A15DC5D681508C766490919BD1 /* ElementsTests.swift */; };
-		BF_0617CDDDB48DE38770265BDD7CEB0DEC /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_0F4D9E9DED7F8875C991F2C8D340AC0F /* Node.swift */; };
-		BF_0966C6144C56C0C83BBB56B5FA204AF7 /* Html.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FR_454B7862EFAF417284E587FDE4F417F7 /* Html.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BF_0BB5E97EDFED595635016E3EE7B8864E /* HtmlSnapshotTesting.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FR_D0E4DB97B85C77E83808CFAA36086DFC /* HtmlSnapshotTesting.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BF_0C554AC6B59BC603FB2F07579BE2E434 /* SnapshotTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_5D868222BE76AE04E2B491E967A6F5F9 /* SnapshotTesting.framework */; };
-		BF_0EF35346B972BAAE87EF93DAE9A11501 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_58555AFF1E96E4DE4F51D747882EF806 /* XCTestManifests.swift */; };
-		BF_1594ED178D46E0C388251F1E04CDE923 /* Aria.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_B83D9298FE6176D48170EF3E46F99CCA /* Aria.swift */; };
-		BF_15A7BDEBF65A443739634DB5C582FC81 /* Html4.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_84247EDD4C722F051D26423EAF9556B4 /* Html4.swift */; };
-		BF_167EC013FBB3444EB137981C73CB1087 /* Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_D02E69C3123E18DA31C95CCEF4F55FD0 /* Events.swift */; };
-		BF_24441D3310AF85C4F376D600FF4C8958 /* Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_D02E69C3123E18DA31C95CCEF4F55FD0 /* Events.swift */; };
-		BF_24991B811CB7C11D52836CDBB9738D91 /* AttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_C37C9D4A3478D7A0906676B07410B4F5 /* AttributesTests.swift */; };
-		BF_24ED05C03DAFDF39FE30EE14FFE8730E /* SnapshotTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_5D868222BE76AE04E2B491E967A6F5F9 /* SnapshotTesting.framework */; };
-		BF_25F0CF956E6CE5A08CF04CC85E0A4295 /* Attributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_75E1F23756D2E133BA75C9CE7559FED4 /* Attributes.swift */; };
-		BF_26D7F20A75ED76315AAC9B5C41D718BC /* ElementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_AF1B21A15DC5D681508C766490919BD1 /* ElementsTests.swift */; };
-		BF_278F2A9F9C6DB1BB09F1B128BEA90554 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_DCB027799D18D0FB625BD4612E72FAC3 /* XCTestManifests.swift */; };
-		BF_281D2611AD316590D461069CDAD1A67C /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_1A5D33291C6AFD143674D746942B98C4 /* Tag.swift */; };
-		BF_2B257D3CB2E9B81C247ADF381DBDB62B /* HtmlSnapshotTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_D0E4DB97B85C77E83808CFAA36086DFC /* HtmlSnapshotTesting.framework */; };
-		BF_2BA1B815F9EC78F22E1CCECFAEE5E44F /* Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_D02E69C3123E18DA31C95CCEF4F55FD0 /* Events.swift */; };
-		BF_2FACF8DC1A08D554CABA3211CB6CA8CD /* Aria.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_B83D9298FE6176D48170EF3E46F99CCA /* Aria.swift */; };
-		BF_347CC9F121F611817634BCED6EED5DC3 /* MediaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_2773FDC63ECF9CA8CE40879B3B0EACC4 /* MediaType.swift */; };
-		BF_39A0B61DCD052204E4318C17B056F7A9 /* ChildOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_40794F1143674CDA249455CEE44CF36F /* ChildOf.swift */; };
-		BF_3B1027C6F72CA257FC500052522A4675 /* Aria.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_B83D9298FE6176D48170EF3E46F99CCA /* Aria.swift */; };
-		BF_3F8D84AFFBE16A644F50F2B06BCBAAB6 /* Html.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_454B7862EFAF417284E587FDE4F417F7 /* Html.framework */; };
-		BF_3F99220FA6DA04A3EBC7BE4A4A1B116B /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_1A5D33291C6AFD143674D746942B98C4 /* Tag.swift */; };
-		BF_46DD45E6A6D9ED65D8141EAD3EA343F8 /* Render.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_F23919B43A726458B14604B66DD07753 /* Render.swift */; };
-		BF_4E262A2097369CAB0947E96FB0D20554 /* MediaTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_FD4A0701B482ECFD3AC801193749B828 /* MediaTypeTests.swift */; };
-		BF_55946568BD6A7CDF27D4FA633035BD5B /* Attributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_75E1F23756D2E133BA75C9CE7559FED4 /* Attributes.swift */; };
-		BF_563D57FE0B16C29A91247EBEEE9EC7B0 /* AttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_C37C9D4A3478D7A0906676B07410B4F5 /* AttributesTests.swift */; };
-		BF_565393F81601512D2C6E41DCE7572D1D /* HtmlSnapshotTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_2C04ED2D80670BFA8174C411C3DCC50B /* HtmlSnapshotTesting.swift */; };
-		BF_595D70987B019CFCD51444943CAE5C72 /* HtmlSnapshotTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_2C04ED2D80670BFA8174C411C3DCC50B /* HtmlSnapshotTesting.swift */; };
-		BF_5A573E2D0A8BAE09309A4785FDFF3D32 /* EventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_5B2816E603A1B4A51D2410FE860B6A73 /* EventsTests.swift */; };
-		BF_605F312BFAC83F9D1E3AA65CB1668889 /* Attributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_75E1F23756D2E133BA75C9CE7559FED4 /* Attributes.swift */; };
-		BF_606F86A6C07CAA3721F9CB6EB65B3636 /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_1A5D33291C6AFD143674D746942B98C4 /* Tag.swift */; };
-		BF_61AB416E385994B572133AB831DA2AB3 /* Attributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_75E1F23756D2E133BA75C9CE7559FED4 /* Attributes.swift */; };
-		BF_637C82D9AF32BC63C5DC411FDD8F48AE /* HtmlSnapshotTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_0738B551A3F66674027ADC5E96FB6433 /* HtmlSnapshotTesting.framework */; };
-		BF_64E82553D6FE85AB9A9A0EC08ADD01ED /* EventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_5B2816E603A1B4A51D2410FE860B6A73 /* EventsTests.swift */; };
-		BF_65F0E3E98B96408A9B918E11902CD2FD /* DebugRender.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_0850AEA78BCAAD1DA3F3C266E13B78CB /* DebugRender.swift */; };
-		BF_6861570A1AAB9862DA92C933E5EFCF37 /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_1A5D33291C6AFD143674D746942B98C4 /* Tag.swift */; };
-		BF_6AD9DAAD0E7665C0FAE92BCADE8F9E5B /* AriaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_EF813CC7FA4018FC2F9A50D2931DDA13 /* AriaTests.swift */; };
-		BF_6C8BBC64ECEFD8A269AF77E4BEDB870E /* HtmlSnapshotTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_705A9DFC1E550226909432DCEE159048 /* HtmlSnapshotTestingTests.swift */; };
-		BF_70B4D5132D2605928522D2B6D09331DB /* Html.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_137ABCB525F73E48E9E0329EC90064AF /* Html.framework */; };
-		BF_7722BFE856EB9FE98F76D23A5344EDA1 /* Html.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FR_A851F66F18D71D07E129E4B1177B980C /* Html.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BF_798DF057BBF3AABE9CA527736486DA11 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_DCB027799D18D0FB625BD4612E72FAC3 /* XCTestManifests.swift */; };
-		BF_7A2DD0BACFFC06AA97C6FE9073DFA83F /* ChildOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_40794F1143674CDA249455CEE44CF36F /* ChildOf.swift */; };
-		BF_7B644F57B477753969E24089C336734C /* AttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_C37C9D4A3478D7A0906676B07410B4F5 /* AttributesTests.swift */; };
-		BF_7B73670CF0825E7E4B35B4754EA0177B /* DebugRender.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_0850AEA78BCAAD1DA3F3C266E13B78CB /* DebugRender.swift */; };
-		BF_7B8DF357C9BBC41FAC46F705E504B8A3 /* MediaTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_FD4A0701B482ECFD3AC801193749B828 /* MediaTypeTests.swift */; };
-		BF_7DA986F804ABF0442B1896498E84A7A8 /* MediaTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_FD4A0701B482ECFD3AC801193749B828 /* MediaTypeTests.swift */; };
-		BF_8362C1DC46756F8CBDFB9BB1345D9A93 /* Render.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_F23919B43A726458B14604B66DD07753 /* Render.swift */; };
-		BF_867E037B341316E7D2ECE2571EEAED23 /* Render.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_F23919B43A726458B14604B66DD07753 /* Render.swift */; };
-		BF_8825CC811E0A3040695CBDACCAA3C14F /* DebugRender.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_0850AEA78BCAAD1DA3F3C266E13B78CB /* DebugRender.swift */; };
-		BF_884C6D4C6BA035CF95DACEBE216B76E2 /* HtmlSnapshotTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_705A9DFC1E550226909432DCEE159048 /* HtmlSnapshotTestingTests.swift */; };
-		BF_8A354EAAB66D8E3DE255C128785F5C81 /* AttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_C37C9D4A3478D7A0906676B07410B4F5 /* AttributesTests.swift */; };
-		BF_8B22EC95C72808E7C4EB9655A38A0B5A /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_0F4D9E9DED7F8875C991F2C8D340AC0F /* Node.swift */; };
-		BF_8B861E44FDF640569DE8FF05357D3A70 /* EventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_5B2816E603A1B4A51D2410FE860B6A73 /* EventsTests.swift */; };
-		BF_8EB2DECBE7B14C281F77000FC19AAD0B /* ElementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_AF1B21A15DC5D681508C766490919BD1 /* ElementsTests.swift */; };
-		BF_935D0BFAB6123CD0DAFE7EE9E69DC063 /* Html.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_137ABCB525F73E48E9E0329EC90064AF /* Html.framework */; };
-		BF_9710C3C0101C3DAF8E7446DED2AB23B6 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_58555AFF1E96E4DE4F51D747882EF806 /* XCTestManifests.swift */; };
-		BF_9A0B1A189B6074024418369D6B665DE3 /* Aria.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_B83D9298FE6176D48170EF3E46F99CCA /* Aria.swift */; };
-		BF_9B72E8029CBB396C619144083CDEE8F5 /* Html4.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_84247EDD4C722F051D26423EAF9556B4 /* Html4.swift */; };
-		BF_9DE76F9CFD7CE49ECAB4FB4A5C8DE42D /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_DCB027799D18D0FB625BD4612E72FAC3 /* XCTestManifests.swift */; };
-		BF_9FDEB02465B72227A53195875566C414 /* ChildOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_40794F1143674CDA249455CEE44CF36F /* ChildOf.swift */; };
-		BF_A348F9E63DAF9CCA333D16623D7E4796 /* HtmlSnapshotTesting.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FR_5C5B2F5B06548979136A244E4C89D95A /* HtmlSnapshotTesting.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BF_A88105ED0725F34B1052BCB720F9F41B /* EventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_5B2816E603A1B4A51D2410FE860B6A73 /* EventsTests.swift */; };
-		BF_AA00EED8F7444475555C9CC04A91796A /* Elements.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_3AEC4DC02DA3D43270FEA9438A693C40 /* Elements.swift */; };
-		BF_AACFA19929DD2D9607FCE8A7ED5E1492 /* HtmlSnapshotTesting.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FR_0738B551A3F66674027ADC5E96FB6433 /* HtmlSnapshotTesting.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BF_AE4039F8D303A38511E101A94D136B23 /* MediaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_2773FDC63ECF9CA8CE40879B3B0EACC4 /* MediaType.swift */; };
-		BF_B2F122C85B8CCF9825F3D203EE89A3C9 /* MediaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_2773FDC63ECF9CA8CE40879B3B0EACC4 /* MediaType.swift */; };
-		BF_B310E9EAD20812D893E237231E3DA4D2 /* Html4.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_84247EDD4C722F051D26423EAF9556B4 /* Html4.swift */; };
-		BF_B6432B24DA58EB3438142CB65615E1D0 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_0F4D9E9DED7F8875C991F2C8D340AC0F /* Node.swift */; };
-		BF_B6E12040B2F4655609A10C1FEC7F37C2 /* HtmlSnapshotTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_5C5B2F5B06548979136A244E4C89D95A /* HtmlSnapshotTesting.framework */; };
-		BF_C1795F68D10F619DA2D7BCFB6F5F58BD /* Html.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_56BF69D04F58D631B62547910FBA29AB /* Html.framework */; };
-		BF_C26E0033107220651F282052426503F6 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_0F4D9E9DED7F8875C991F2C8D340AC0F /* Node.swift */; };
-		BF_C53F17FDB01D62BD227E30FB03C68D3F /* Html.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FR_137ABCB525F73E48E9E0329EC90064AF /* Html.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BF_C71D5072A7281A91A9B475DCE86C2B21 /* Elements.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_3AEC4DC02DA3D43270FEA9438A693C40 /* Elements.swift */; };
-		BF_CCD2256A9DBC486987F3F43551B223A9 /* AriaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_EF813CC7FA4018FC2F9A50D2931DDA13 /* AriaTests.swift */; };
-		BF_CE61822D94187BF3F992DE42B316C3BA /* Html.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FR_56BF69D04F58D631B62547910FBA29AB /* Html.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BF_CE9BD77978ABBB3945304ED5FFDE4D22 /* DebugRender.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_0850AEA78BCAAD1DA3F3C266E13B78CB /* DebugRender.swift */; };
-		BF_CF0E86D3302994FF9A9C54677F4E5A66 /* SnapshotTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_5D868222BE76AE04E2B491E967A6F5F9 /* SnapshotTesting.framework */; };
-		BF_D164F90CEF6B6A5A9B50B0E4C819B853 /* AriaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_EF813CC7FA4018FC2F9A50D2931DDA13 /* AriaTests.swift */; };
-		BF_D1E67FAB41094DD199979F735674B59C /* Html.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_454B7862EFAF417284E587FDE4F417F7 /* Html.framework */; };
-		BF_D1EC6634E48CAA46F330C4A722EC0337 /* Html.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_56BF69D04F58D631B62547910FBA29AB /* Html.framework */; };
-		BF_D6EFA4CEC590928E8746DAA42C8BE6E7 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_58555AFF1E96E4DE4F51D747882EF806 /* XCTestManifests.swift */; };
-		BF_E37CBCFB5EB106C9B0B47D83BD00501B /* Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_D02E69C3123E18DA31C95CCEF4F55FD0 /* Events.swift */; };
-		BF_EA15C26493DFD83A59AB9BE8E0D7AA4A /* AriaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_EF813CC7FA4018FC2F9A50D2931DDA13 /* AriaTests.swift */; };
-		BF_EDF30C936D87DB063C818C532B5BAF18 /* Elements.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_3AEC4DC02DA3D43270FEA9438A693C40 /* Elements.swift */; };
-		BF_EF48C76BDF60C8580D714F851E5D88B0 /* MediaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_2773FDC63ECF9CA8CE40879B3B0EACC4 /* MediaType.swift */; };
-		BF_F0C75B20B63A27C1EC68B41EB07496EB /* ElementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_AF1B21A15DC5D681508C766490919BD1 /* ElementsTests.swift */; };
-		BF_F3DFC44A453A05F52FC0E68020D84D5B /* Elements.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_3AEC4DC02DA3D43270FEA9438A693C40 /* Elements.swift */; };
-		BF_F3FA3DF870D54FB9B46B80B6B90FA204 /* MediaTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_FD4A0701B482ECFD3AC801193749B828 /* MediaTypeTests.swift */; };
-		BF_F418B64B4E716428B1A60543E3BF53F0 /* Html.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_A851F66F18D71D07E129E4B1177B980C /* Html.framework */; };
-		BF_F990810FF37D0B351B5B147A29A983C4 /* HtmlSnapshotTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_705A9DFC1E550226909432DCEE159048 /* HtmlSnapshotTestingTests.swift */; };
-		BF_FC2286DCB1EFFAF5878808FB40A6CDF0 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_DCB027799D18D0FB625BD4612E72FAC3 /* XCTestManifests.swift */; };
-		BF_FFADB3958F2E3230AE1E012A0E69DC6A /* Render.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_F23919B43A726458B14604B66DD07753 /* Render.swift */; };
+		0115EB8F32DBE433E1050DA098737BE0 /* AriaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A9352E08F9F5B85DD11E79B811B73B /* AriaTests.swift */; };
+		01A10D4EA430E797FFA31BFEB45627ED /* Elements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B71DD55BD5D66D1EA732D28BD0BE6E9 /* Elements.swift */; };
+		04D70307F85F1E61E236EDC0AD42FE91 /* MediaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BDAF91C40D03C3A7E69A8BBFD69EC8D /* MediaType.swift */; };
+		0B3605A85BAE1007B25791B8083A399A /* Attributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F28E121F5FC3715428AEEA82FC5F98FD /* Attributes.swift */; };
+		0E0A73032A028D9EE9E751B1FEFAF847 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9DCA8DE3E7090A3C282A73883D7442 /* XCTestManifests.swift */; };
+		0E374A295AE1B8D569BC10C41D6BAE75 /* Render.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA45861B39F4E37CDDDCCABB2A53A1E /* Render.swift */; };
+		0FD25ADBA170DC483E8414EAE4EAC895 /* ChildOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C9046535B58D48C7C30DB39E006A8E /* ChildOf.swift */; };
+		10CB995C346E4F6BB739245CF35BFD6C /* MediaTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 708E8F50973AA5115D39081C8C682A7A /* MediaTypeTests.swift */; };
+		121E7E9C359BC98E386560602A458F3A /* Attributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F28E121F5FC3715428AEEA82FC5F98FD /* Attributes.swift */; };
+		16533F003832605F81D5B2D7EC932B2F /* Html4.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6618A20707AF30DE9D556FA2DC9E7739 /* Html4.swift */; };
+		1866BB4BEF6300372E372FD4D543C5E2 /* AriaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A9352E08F9F5B85DD11E79B811B73B /* AriaTests.swift */; };
+		1BE39F74F999E0822E97F961D75C8216 /* ElementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC7C33F80B9F9085D9ECAF42D6F16B0 /* ElementsTests.swift */; };
+		1C810F7A3295BC0709C67CF5491DF03A /* AttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC51C18E3303316FFBD4A3A9EF5BFA9 /* AttributesTests.swift */; };
+		1D5FBAD5A5389306A6E88211685AB401 /* ChildOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C9046535B58D48C7C30DB39E006A8E /* ChildOf.swift */; };
+		2099BAB970D80BEC0B54849F169D1F82 /* HtmlSnapshotTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A8D435A245A1B388B6B9DCA4C85450 /* HtmlSnapshotTestingTests.swift */; };
+		21BC55C1164331DF516D6A29D32B0826 /* Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4BCE93E0F76CBEC0BD72AE17F41267 /* Events.swift */; };
+		22D4EFC4BB4A144D74447015A3508FD8 /* SnapshotTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A7CCBDB5117940D470A385FB24A2F061 /* SnapshotTesting.framework */; };
+		232D4FCB46A640784F508A71A1B838B4 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115C2537BD6C462339847B6D06893956 /* Node.swift */; };
+		282FAD7E0F6982CF50D0F604079C8135 /* DebugRender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 369859355DF7EFF616957797418CA39A /* DebugRender.swift */; };
+		2CF0C74814B7E7DEE5001BCB7E0B0465 /* MediaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BDAF91C40D03C3A7E69A8BBFD69EC8D /* MediaType.swift */; };
+		320F85D14E26D20C47FD2167B68B7B45 /* HtmlSnapshotTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F74E777DD008915447BBB102F893ED38 /* HtmlSnapshotTesting.framework */; };
+		339017E55A0C394698EA8C9A13E376E5 /* AriaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A9352E08F9F5B85DD11E79B811B73B /* AriaTests.swift */; };
+		342033AF8BF6A1CAE8DAE52D05DC5D84 /* Aria.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD134F1DBDA964CE05DF7C22ACA72A49 /* Aria.swift */; };
+		42E5693ECA0E8F31F6D69A63F58F2FF9 /* MediaTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 708E8F50973AA5115D39081C8C682A7A /* MediaTypeTests.swift */; };
+		456214C907B6E2362F1E8B53E9F6A88E /* Html.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B34F431D275160E7E8731AAD1D6A329 /* Html.framework */; };
+		45D9DE86DABC8B5B5BC3CA5F96E5C9F7 /* Elements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B71DD55BD5D66D1EA732D28BD0BE6E9 /* Elements.swift */; };
+		45DF47B21461F09D2C0246DD8D995EF3 /* Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4BCE93E0F76CBEC0BD72AE17F41267 /* Events.swift */; };
+		4812E11C2178735574880DFBF7648F41 /* EventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E54612F8B09ADB7F65E64E0560CA4788 /* EventsTests.swift */; };
+		48B85DE1CC1FB6963E7B8B9F9CF3971C /* Elements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B71DD55BD5D66D1EA732D28BD0BE6E9 /* Elements.swift */; };
+		4A21B49606D1963916E5CB56B2E24F94 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115C2537BD6C462339847B6D06893956 /* Node.swift */; };
+		4CB4376B42DA8FCCFA23B0EEADD8BFA5 /* HtmlSnapshotTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A8D435A245A1B388B6B9DCA4C85450 /* HtmlSnapshotTestingTests.swift */; };
+		50CD9F87EC29298AB3AF7DB95E1BF648 /* HtmlSnapshotTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27254C973FAFC7DBB8BF87EC41C30E53 /* HtmlSnapshotTesting.swift */; };
+		519F8663ADF038097E7CB6998A8EEA00 /* ElementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC7C33F80B9F9085D9ECAF42D6F16B0 /* ElementsTests.swift */; };
+		55136F7ABEA6B6E95DF69567D1484A0B /* HtmlSnapshotTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27254C973FAFC7DBB8BF87EC41C30E53 /* HtmlSnapshotTesting.swift */; };
+		67DBA93187389C32312B03EC591CFC5B /* Html4.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6618A20707AF30DE9D556FA2DC9E7739 /* Html4.swift */; };
+		68D29CA1EC6653C73FF489391C239F85 /* ChildOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C9046535B58D48C7C30DB39E006A8E /* ChildOf.swift */; };
+		700952E0C833CD56069B1E9A82CBF072 /* HtmlSnapshotTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27254C973FAFC7DBB8BF87EC41C30E53 /* HtmlSnapshotTesting.swift */; };
+		73F75EC489DE8EB634388279CF2B24E0 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9DCA8DE3E7090A3C282A73883D7442 /* XCTestManifests.swift */; };
+		76F3F70426E382433C0B9C9309AB595E /* HtmlSnapshotTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A8D435A245A1B388B6B9DCA4C85450 /* HtmlSnapshotTestingTests.swift */; };
+		778780B4B83AEB8DE746BAB6B4A0A32A /* MediaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BDAF91C40D03C3A7E69A8BBFD69EC8D /* MediaType.swift */; };
+		780C67A46BA9D2361F76C584529B4E16 /* DebugRender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 369859355DF7EFF616957797418CA39A /* DebugRender.swift */; };
+		78CBCD400873B9A93C7B8E502E382FB0 /* Html.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9E126A3CA355B25D21B2623F839076B9 /* Html.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		79064327BF44307D2701787813E95EB1 /* Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4BCE93E0F76CBEC0BD72AE17F41267 /* Events.swift */; };
+		7AF704E5498B7F695F8E7AD7D3525B66 /* Html.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B34F431D275160E7E8731AAD1D6A329 /* Html.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		7EB5EC4C256933659B82A6FA8322B4FB /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115C2537BD6C462339847B6D06893956 /* Node.swift */; };
+		810FE3698DC4F588392CED75E74379F3 /* DebugRender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 369859355DF7EFF616957797418CA39A /* DebugRender.swift */; };
+		83A3863FABFA08DDD2330E2A0D1DA364 /* EventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E54612F8B09ADB7F65E64E0560CA4788 /* EventsTests.swift */; };
+		8513AA929DA47348ED3F9A0DC62987D9 /* Elements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B71DD55BD5D66D1EA732D28BD0BE6E9 /* Elements.swift */; };
+		87B59F892F691C9A4C47667811D19133 /* Attributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F28E121F5FC3715428AEEA82FC5F98FD /* Attributes.swift */; };
+		88805D464199C4C7FAF291745ECAAD63 /* AttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC51C18E3303316FFBD4A3A9EF5BFA9 /* AttributesTests.swift */; };
+		8EFA74B726CDCB91161A1E6974BF3BC0 /* Render.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA45861B39F4E37CDDDCCABB2A53A1E /* Render.swift */; };
+		90E66630293805103BCF40AB6CAEC7F6 /* Render.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA45861B39F4E37CDDDCCABB2A53A1E /* Render.swift */; };
+		943511A6917C0D324955E72640964FE9 /* DebugRender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 369859355DF7EFF616957797418CA39A /* DebugRender.swift */; };
+		9597C5A3B84198D3A377022953A8A4D7 /* Html.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB046D1C05F47D3AD9B2CAE7CBD4F577 /* Html.framework */; };
+		9CC96B55188CC30804706A896AD85920 /* AriaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A9352E08F9F5B85DD11E79B811B73B /* AriaTests.swift */; };
+		9DE35B19DBD01BF99E3841C5D6A3FEF5 /* HtmlSnapshotTesting.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E46CB2B107F502CC7E8D939854F0D9CB /* HtmlSnapshotTesting.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A0A220928D69834EC68CA70B72A8B03E /* Html.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B34F431D275160E7E8731AAD1D6A329 /* Html.framework */; };
+		A54E5956BC01802D7679F586171E619E /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417A595A39394207A53E54ACAD07FB15 /* XCTestManifests.swift */; };
+		A5E8D6FD70F957651D21573A306E7426 /* Aria.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD134F1DBDA964CE05DF7C22ACA72A49 /* Aria.swift */; };
+		A7C98A58CF8B7710692FB2A3D16DBA14 /* Attributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F28E121F5FC3715428AEEA82FC5F98FD /* Attributes.swift */; };
+		A9B2163DF58907BB6D742D12228CB86C /* HtmlSnapshotTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CCC4F55894F2A87CC63B036B604930DC /* HtmlSnapshotTesting.framework */; };
+		ACB161F66536641251BB19DEBD37AFB7 /* EventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E54612F8B09ADB7F65E64E0560CA4788 /* EventsTests.swift */; };
+		AEDDC90F978435848F8769AB9E57C021 /* Html4.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6618A20707AF30DE9D556FA2DC9E7739 /* Html4.swift */; };
+		AFE87284ABDA54DE2ABAC910039CA450 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417A595A39394207A53E54ACAD07FB15 /* XCTestManifests.swift */; };
+		B2D1F981F0FDEACC1FF2C571D153A9B2 /* EventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E54612F8B09ADB7F65E64E0560CA4788 /* EventsTests.swift */; };
+		B5B05E827B38F5AD3B7D100CB53449FC /* MediaTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 708E8F50973AA5115D39081C8C682A7A /* MediaTypeTests.swift */; };
+		B5F6444A4BF392B405B7B2395C2D8CBB /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5513765DDE12320E99FB4423D8117DEB /* Tag.swift */; };
+		B720C142F7063B9B6F16078913D917B0 /* Render.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA45861B39F4E37CDDDCCABB2A53A1E /* Render.swift */; };
+		B8A2EEB6FB193AE66A07C6ED862A347D /* ElementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC7C33F80B9F9085D9ECAF42D6F16B0 /* ElementsTests.swift */; };
+		BA824EECB7944B35FA30C5B54496F616 /* HtmlSnapshotTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E46CB2B107F502CC7E8D939854F0D9CB /* HtmlSnapshotTesting.framework */; };
+		BAE3237DCE9A0E30E5D34F994C0405E9 /* Html.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E126A3CA355B25D21B2623F839076B9 /* Html.framework */; };
+		BB979161058B8200CC85CEB775E17EF8 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9DCA8DE3E7090A3C282A73883D7442 /* XCTestManifests.swift */; };
+		C0FD32A0ABF3F8F85B90E6D26C6BA156 /* MediaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BDAF91C40D03C3A7E69A8BBFD69EC8D /* MediaType.swift */; };
+		C2F8882B4B3F347E3480C2811FC9C44A /* MediaTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 708E8F50973AA5115D39081C8C682A7A /* MediaTypeTests.swift */; };
+		C305AC4208160CFF487FD25B1A5DA2FB /* Html.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B4B440160381819677F8C69057C87D11 /* Html.framework */; };
+		C4E4C2D595529DB466C13921E3BC14DF /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5513765DDE12320E99FB4423D8117DEB /* Tag.swift */; };
+		C58132C4ABBB76F2954234280C6AB511 /* ElementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC7C33F80B9F9085D9ECAF42D6F16B0 /* ElementsTests.swift */; };
+		C91F77DBA9D7A5455DD17F14C5C18A58 /* Aria.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD134F1DBDA964CE05DF7C22ACA72A49 /* Aria.swift */; };
+		D387E5D35A0C9F0E33610FF253829CBC /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115C2537BD6C462339847B6D06893956 /* Node.swift */; };
+		D4DA6A5CC597EA32EE5023AA44E910BD /* HtmlSnapshotTesting.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F74E777DD008915447BBB102F893ED38 /* HtmlSnapshotTesting.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D803576621BCE4F021E29A85DFA974AE /* ChildOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C9046535B58D48C7C30DB39E006A8E /* ChildOf.swift */; };
+		D891E0698D5A9D1B852171D14C495EC5 /* AttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC51C18E3303316FFBD4A3A9EF5BFA9 /* AttributesTests.swift */; };
+		DC0BE7BC69BB026C7C04105CEDDD7902 /* Html.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E126A3CA355B25D21B2623F839076B9 /* Html.framework */; };
+		DCB928080545ED169BBA87D8883AB8FB /* Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4BCE93E0F76CBEC0BD72AE17F41267 /* Events.swift */; };
+		DCEDD7692E68C69E9001FCD352B4941E /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417A595A39394207A53E54ACAD07FB15 /* XCTestManifests.swift */; };
+		DDA36E7452BE4418B3427B6C398AA22D /* Aria.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD134F1DBDA964CE05DF7C22ACA72A49 /* Aria.swift */; };
+		E48B4BC441FC140031399C59E9523494 /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5513765DDE12320E99FB4423D8117DEB /* Tag.swift */; };
+		E5A6BD4678FA157D7F40A9FDF00A72BE /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5513765DDE12320E99FB4423D8117DEB /* Tag.swift */; };
+		E5D009555297E3FA942F0CC1F2E1C7FC /* SnapshotTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A7CCBDB5117940D470A385FB24A2F061 /* SnapshotTesting.framework */; };
+		E6A494B3721C07F9D64140D17A472FE5 /* Html4.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6618A20707AF30DE9D556FA2DC9E7739 /* Html4.swift */; };
+		EE3067D518DFD187326B92395053CA72 /* Html.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B4B440160381819677F8C69057C87D11 /* Html.framework */; };
+		F374E58D4F1F115FE772AA42354E16CC /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9DCA8DE3E7090A3C282A73883D7442 /* XCTestManifests.swift */; };
+		F69BED84D9CCA475C7569E5CCAEA580D /* AttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC51C18E3303316FFBD4A3A9EF5BFA9 /* AttributesTests.swift */; };
+		F8F107C647A65E29C5B0892D0953B2C4 /* SnapshotTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A7CCBDB5117940D470A385FB24A2F061 /* SnapshotTesting.framework */; };
+		F93FE2441E72FF23F69F513EAE3F90E4 /* Html.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AB046D1C05F47D3AD9B2CAE7CBD4F577 /* Html.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F99DF83A502E357A1E286E47CDB6EC52 /* Html.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B4B440160381819677F8C69057C87D11 /* Html.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		FD0BAE925FA5CB30F4B34CD53ECCA034 /* HtmlSnapshotTesting.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CCC4F55894F2A87CC63B036B604930DC /* HtmlSnapshotTesting.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		CIP_3F002AD65FB7CBF51126C49E45500E71 /* PBXContainerItemProxy */ = {
+		0BF8AA2AB0F08B5CDB439089887CE326 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = P_71156FC3BAF7CC8140053AE66992A365 /* Project object */;
+			containerPortal = CFEA2F996BC045811F1828EEFB911A38 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = NT_35F4D7F166DB6BD11B0FE52D126BA796;
+			remoteGlobalIDString = 387DD84FD9EB67768EA91AEA30999728;
+			remoteInfo = Html_macOS;
+		};
+		42AB772B2F24E967596BE368C8F28BEC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CFEA2F996BC045811F1828EEFB911A38 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 387DD84FD9EB67768EA91AEA30999728;
+			remoteInfo = Html_macOS;
+		};
+		4B300CBD2D7222D89A2D78871D93E8D0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CFEA2F996BC045811F1828EEFB911A38 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 875B8C7FB1A8896A28D7B853F513CFD6;
+			remoteInfo = Html_tvOS;
+		};
+		6FECA1441A0146880FF034B00A469E96 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CFEA2F996BC045811F1828EEFB911A38 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F810FEAA71B0586D1B6CE7F412FF7D3E;
+			remoteInfo = Html_iOS;
+		};
+		70611457C4A3A4E01EF124FF77B81AAC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CFEA2F996BC045811F1828EEFB911A38 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F810FEAA71B0586D1B6CE7F412FF7D3E;
+			remoteInfo = Html_iOS;
+		};
+		79A3189C141EEEE59F8E0A813AB24575 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CFEA2F996BC045811F1828EEFB911A38 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2BA1D0CC8309950F649BDD13CBCDE39B;
+			remoteInfo = HtmlSnapshotTesting_tvOS;
+		};
+		82C2DC31F5C7E40CD7373615416F1D1B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CFEA2F996BC045811F1828EEFB911A38 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9D4E25C5088CA6D3CA55EC77E0EDCA7D;
 			remoteInfo = HtmlSnapshotTesting_macOS;
 		};
-		CIP_428162E099AAE498F66071D85657F7DD /* PBXContainerItemProxy */ = {
+		928BB69B1A4CE587A6E451C15AAEDEBF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = P_71156FC3BAF7CC8140053AE66992A365 /* Project object */;
+			containerPortal = CFEA2F996BC045811F1828EEFB911A38 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = NT_3DAB1392843626D3536CA19914B502C8;
-			remoteInfo = Html_macOS;
-		};
-		CIP_5E11A82DA491889A8D1375324A3CFCA8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = P_71156FC3BAF7CC8140053AE66992A365 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = NT_E3DC39F33A9CC5CE33CBED0C7A0716AB;
-			remoteInfo = Html_tvOS;
-		};
-		CIP_825D966EF836E0E71CF6881A75269FA8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = P_71156FC3BAF7CC8140053AE66992A365 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = NT_391C0E1A822D646F708827B001EB83D2;
-			remoteInfo = Html_iOS;
-		};
-		CIP_89EDC2A7F6D7562F8EF940B46BAA6DBA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = P_71156FC3BAF7CC8140053AE66992A365 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = NT_5881CD49A13FAFE4B62A050F5942B296;
-			remoteInfo = HtmlSnapshotTesting_iOS;
-		};
-		CIP_8DF159F48FA6256DEFC4C32AEBD165C6 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = P_71156FC3BAF7CC8140053AE66992A365 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = NT_3DAB1392843626D3536CA19914B502C8;
-			remoteInfo = Html_macOS;
-		};
-		CIP_DA359FC6B1376BF6D720448BF666D52C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = P_71156FC3BAF7CC8140053AE66992A365 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = NT_E3DC39F33A9CC5CE33CBED0C7A0716AB;
-			remoteInfo = Html_tvOS;
-		};
-		CIP_ED65AA7D2A04B134645AC114BE634B38 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = P_71156FC3BAF7CC8140053AE66992A365 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = NT_A56629B8583F524D8DABDEB1B3B5FCB8;
+			remoteGlobalIDString = ECF3589FFC8B598E275967EA4DCE9E99;
 			remoteInfo = Html_watchOS;
 		};
-		CIP_FD6FA1F02F1A1056267C6CC6ABD3BC79 /* PBXContainerItemProxy */ = {
+		A97507570D2BD13B832930E5D3620D17 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = P_71156FC3BAF7CC8140053AE66992A365 /* Project object */;
+			containerPortal = CFEA2F996BC045811F1828EEFB911A38 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = NT_391C0E1A822D646F708827B001EB83D2;
-			remoteInfo = Html_iOS;
+			remoteGlobalIDString = 83770D5D7E5A47BE568F39AD0B92F45D;
+			remoteInfo = HtmlSnapshotTesting_iOS;
 		};
-		CIP_FEC3F08F65BDD69FD4ED10630D2DA027 /* PBXContainerItemProxy */ = {
+		B5858D39C442D31EDFF46EBCF4082E03 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = P_71156FC3BAF7CC8140053AE66992A365 /* Project object */;
+			containerPortal = CFEA2F996BC045811F1828EEFB911A38 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = NT_8DA0D6B0D3FB381C06CED88C8D8EB1F3;
-			remoteInfo = HtmlSnapshotTesting_tvOS;
+			remoteGlobalIDString = 875B8C7FB1A8896A28D7B853F513CFD6;
+			remoteInfo = Html_tvOS;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		CFBP_0EF97FE9237F775F6378EF6C8ADDF746 /* Embed Frameworks */ = {
+		1A46D042D093C8DAA19EB88DDF04DBE6 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				BF_0966C6144C56C0C83BBB56B5FA204AF7 /* Html.framework in Embed Frameworks */,
+				D4DA6A5CC597EA32EE5023AA44E910BD /* HtmlSnapshotTesting.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CFBP_104F460684C31F51F582A752718D1F52 /* Embed Frameworks */ = {
+		51009AB3649DC6CF3191530574D11E6B /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				BF_A348F9E63DAF9CCA333D16623D7E4796 /* HtmlSnapshotTesting.framework in Embed Frameworks */,
+				FD0BAE925FA5CB30F4B34CD53ECCA034 /* HtmlSnapshotTesting.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CFBP_3518DAB421FD09511C350B2070048EC1 /* Embed Frameworks */ = {
+		90ECE35850EFF663540570E5F54135BA /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				BF_C53F17FDB01D62BD227E30FB03C68D3F /* Html.framework in Embed Frameworks */,
+				F99DF83A502E357A1E286E47CDB6EC52 /* Html.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CFBP_454D57A9593439E7D0AA015E804AF1A5 /* Embed Frameworks */ = {
+		9DFFFD731E4FD8472D8F2C29A36A7643 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				BF_CE61822D94187BF3F992DE42B316C3BA /* Html.framework in Embed Frameworks */,
+				9DE35B19DBD01BF99E3841C5D6A3FEF5 /* HtmlSnapshotTesting.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CFBP_6BAA655AFDC030DC4A415B276A855D49 /* Embed Frameworks */ = {
+		C80455EA9C5211ED801825B5F017B178 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				BF_AACFA19929DD2D9607FCE8A7ED5E1492 /* HtmlSnapshotTesting.framework in Embed Frameworks */,
+				78CBCD400873B9A93C7B8E502E382FB0 /* Html.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CFBP_ED3D783EB6C94698CCB70104EB35CB95 /* Embed Frameworks */ = {
+		D8CF69C6326F606601570C2C4DC9B81A /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				BF_0BB5E97EDFED595635016E3EE7B8864E /* HtmlSnapshotTesting.framework in Embed Frameworks */,
+				7AF704E5498B7F695F8E7AD7D3525B66 /* Html.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CFBP_F4A017195DD6933F2FEC397593218ECD /* Embed Frameworks */ = {
+		F1A7E8AA26346DB89C3B78EEE9C87877 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				BF_7722BFE856EB9FE98F76D23A5344EDA1 /* Html.framework in Embed Frameworks */,
+				F93FE2441E72FF23F69F513EAE3F90E4 /* Html.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -260,320 +260,269 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		FR_0738B551A3F66674027ADC5E96FB6433 /* HtmlSnapshotTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = HtmlSnapshotTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_0850AEA78BCAAD1DA3F3C266E13B78CB /* DebugRender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugRender.swift; sourceTree = "<group>"; };
-		FR_0F4D9E9DED7F8875C991F2C8D340AC0F /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
-		FR_137ABCB525F73E48E9E0329EC90064AF /* Html.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Html.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_186C495A13918FA9B6DC64977C0BEF84 /* HtmlTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HtmlTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_1A5D33291C6AFD143674D746942B98C4 /* Tag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tag.swift; sourceTree = "<group>"; };
-		FR_207D0187D4F8218348DEFA383C2B838C /* HtmlTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HtmlTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_2773FDC63ECF9CA8CE40879B3B0EACC4 /* MediaType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaType.swift; sourceTree = "<group>"; };
-		FR_2C04ED2D80670BFA8174C411C3DCC50B /* HtmlSnapshotTesting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HtmlSnapshotTesting.swift; sourceTree = "<group>"; };
-		FR_3AEC4DC02DA3D43270FEA9438A693C40 /* Elements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Elements.swift; sourceTree = "<group>"; };
-		FR_4024F32C566BA88E351F72CADE1F9287 /* HtmlSnapshotTestingTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HtmlSnapshotTestingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_40794F1143674CDA249455CEE44CF36F /* ChildOf.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChildOf.swift; sourceTree = "<group>"; };
-		FR_426253E0818C46FC1DB97614AD713830 /* HtmlSnapshotTestingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HtmlSnapshotTestingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_44D3298F923225BC3162818D9F543BBC /* HtmlTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HtmlTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_454B7862EFAF417284E587FDE4F417F7 /* Html.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Html.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_56BF69D04F58D631B62547910FBA29AB /* Html.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Html.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_58555AFF1E96E4DE4F51D747882EF806 /* XCTestManifests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
-		FR_5B2816E603A1B4A51D2410FE860B6A73 /* EventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsTests.swift; sourceTree = "<group>"; };
-		FR_5C5B2F5B06548979136A244E4C89D95A /* HtmlSnapshotTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = HtmlSnapshotTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_5D868222BE76AE04E2B491E967A6F5F9 /* SnapshotTesting.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SnapshotTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_60FE2FD7DED430CDB41B57A0CAECD79A /* HtmlSnapshotTestingTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HtmlSnapshotTestingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_705A9DFC1E550226909432DCEE159048 /* HtmlSnapshotTestingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HtmlSnapshotTestingTests.swift; sourceTree = "<group>"; };
-		FR_75E1F23756D2E133BA75C9CE7559FED4 /* Attributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Attributes.swift; sourceTree = "<group>"; };
-		FR_84247EDD4C722F051D26423EAF9556B4 /* Html4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Html4.swift; sourceTree = "<group>"; };
-		FR_87FEDF3B848906588C41DBE9A6F6E75E /* HtmlTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HtmlTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_A851F66F18D71D07E129E4B1177B980C /* Html.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Html.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_AF1B21A15DC5D681508C766490919BD1 /* ElementsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementsTests.swift; sourceTree = "<group>"; };
-		FR_B83D9298FE6176D48170EF3E46F99CCA /* Aria.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Aria.swift; sourceTree = "<group>"; };
-		FR_C37C9D4A3478D7A0906676B07410B4F5 /* AttributesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributesTests.swift; sourceTree = "<group>"; };
-		FR_D02E69C3123E18DA31C95CCEF4F55FD0 /* Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Events.swift; sourceTree = "<group>"; };
-		FR_D0E4DB97B85C77E83808CFAA36086DFC /* HtmlSnapshotTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = HtmlSnapshotTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_DCB027799D18D0FB625BD4612E72FAC3 /* XCTestManifests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
-		FR_EF813CC7FA4018FC2F9A50D2931DDA13 /* AriaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AriaTests.swift; sourceTree = "<group>"; };
-		FR_F23919B43A726458B14604B66DD07753 /* Render.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Render.swift; sourceTree = "<group>"; };
-		FR_FD4A0701B482ECFD3AC801193749B828 /* MediaTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTypeTests.swift; sourceTree = "<group>"; };
+		05BD2B8FDAC04D4E797449823E9C94AB /* HtmlSnapshotTestingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HtmlSnapshotTestingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		0A94FF60072BECC2CA97CA8C647A8D43 /* HtmlTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HtmlTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		0E4BCE93E0F76CBEC0BD72AE17F41267 /* Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Events.swift; sourceTree = "<group>"; };
+		115C2537BD6C462339847B6D06893956 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
+		27254C973FAFC7DBB8BF87EC41C30E53 /* HtmlSnapshotTesting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HtmlSnapshotTesting.swift; sourceTree = "<group>"; };
+		369859355DF7EFF616957797418CA39A /* DebugRender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugRender.swift; sourceTree = "<group>"; };
+		3B34F431D275160E7E8731AAD1D6A329 /* Html.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Html.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3D9DCA8DE3E7090A3C282A73883D7442 /* XCTestManifests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
+		417A595A39394207A53E54ACAD07FB15 /* XCTestManifests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
+		46849DCB7BA41A018AB4F4CACB5D9E45 /* HtmlTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HtmlTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4DC7C33F80B9F9085D9ECAF42D6F16B0 /* ElementsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementsTests.swift; sourceTree = "<group>"; };
+		5513765DDE12320E99FB4423D8117DEB /* Tag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tag.swift; sourceTree = "<group>"; };
+		6618A20707AF30DE9D556FA2DC9E7739 /* Html4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Html4.swift; sourceTree = "<group>"; };
+		6B71DD55BD5D66D1EA732D28BD0BE6E9 /* Elements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Elements.swift; sourceTree = "<group>"; };
+		708E8F50973AA5115D39081C8C682A7A /* MediaTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTypeTests.swift; sourceTree = "<group>"; };
+		7BDAF91C40D03C3A7E69A8BBFD69EC8D /* MediaType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaType.swift; sourceTree = "<group>"; };
+		88A8D435A245A1B388B6B9DCA4C85450 /* HtmlSnapshotTestingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HtmlSnapshotTestingTests.swift; sourceTree = "<group>"; };
+		8AA45861B39F4E37CDDDCCABB2A53A1E /* Render.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Render.swift; sourceTree = "<group>"; };
+		9765C9A1F174B7B2CFB9E078325F971F /* HtmlTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HtmlTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9E126A3CA355B25D21B2623F839076B9 /* Html.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Html.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A7CCBDB5117940D470A385FB24A2F061 /* SnapshotTesting.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SnapshotTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A8A9352E08F9F5B85DD11E79B811B73B /* AriaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AriaTests.swift; sourceTree = "<group>"; };
+		AB046D1C05F47D3AD9B2CAE7CBD4F577 /* Html.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Html.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B3E3F6B828962116F3E9C05DAF1FB06C /* HtmlTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HtmlTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		B4B440160381819677F8C69057C87D11 /* Html.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Html.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B8C9046535B58D48C7C30DB39E006A8E /* ChildOf.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChildOf.swift; sourceTree = "<group>"; };
+		CAC51C18E3303316FFBD4A3A9EF5BFA9 /* AttributesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributesTests.swift; sourceTree = "<group>"; };
+		CCC4F55894F2A87CC63B036B604930DC /* HtmlSnapshotTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = HtmlSnapshotTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DD134F1DBDA964CE05DF7C22ACA72A49 /* Aria.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Aria.swift; sourceTree = "<group>"; };
+		E46CB2B107F502CC7E8D939854F0D9CB /* HtmlSnapshotTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = HtmlSnapshotTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E54612F8B09ADB7F65E64E0560CA4788 /* EventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsTests.swift; sourceTree = "<group>"; };
+		F1CBC16061375C51FBFB40C4BEAED518 /* HtmlSnapshotTestingTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HtmlSnapshotTestingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F28E121F5FC3715428AEEA82FC5F98FD /* Attributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Attributes.swift; sourceTree = "<group>"; };
+		F74E777DD008915447BBB102F893ED38 /* HtmlSnapshotTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = HtmlSnapshotTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FC64ED50B6E4126DFEAC21391EE00590 /* HtmlSnapshotTestingTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HtmlSnapshotTestingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		FBP_29AA1172FF0196656995D067990E362F /* Frameworks */ = {
+		21F8685660D3998ACC35B487A6BB70D4 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_F418B64B4E716428B1A60543E3BF53F0 /* Html.framework in Frameworks */,
+				A0A220928D69834EC68CA70B72A8B03E /* Html.framework in Frameworks */,
+				F8F107C647A65E29C5B0892D0953B2C4 /* SnapshotTesting.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_2C81E5F0230FB12D799B2A24DA3E8879 /* Frameworks */ = {
+		268237254571CC5A45FB6AB774D4C5C6 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_637C82D9AF32BC63C5DC411FDD8F48AE /* HtmlSnapshotTesting.framework in Frameworks */,
+				A9B2163DF58907BB6D742D12228CB86C /* HtmlSnapshotTesting.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_3E0B8227123B1F3E772E515DEF4E5ED7 /* Frameworks */ = {
+		34A8E9EF520920AF1AB0B706E6D3E5DC /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_3F8D84AFFBE16A644F50F2B06BCBAAB6 /* Html.framework in Frameworks */,
+				EE3067D518DFD187326B92395053CA72 /* Html.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_A1466079479EC0AA7AB058D9EDB8F234 /* Frameworks */ = {
+		390B06E86D5FD376E5E7C443F109999C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_C1795F68D10F619DA2D7BCFB6F5F58BD /* Html.framework in Frameworks */,
+				BA824EECB7944B35FA30C5B54496F616 /* HtmlSnapshotTesting.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_DC02A60B50A5C4A75A5DF850DFAABFBB /* Frameworks */ = {
+		5058F16FF516A6E11453F0890D8A0571 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_D1E67FAB41094DD199979F735674B59C /* Html.framework in Frameworks */,
-				BF_CF0E86D3302994FF9A9C54677F4E5A66 /* SnapshotTesting.framework in Frameworks */,
+				456214C907B6E2362F1E8B53E9F6A88E /* Html.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_E22C0A1C815DBF1E5E42519734360A4D /* Frameworks */ = {
+		5A5D749546946AF2686829C2088C0A4D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_935D0BFAB6123CD0DAFE7EE9E69DC063 /* Html.framework in Frameworks */,
-				BF_0C554AC6B59BC603FB2F07579BE2E434 /* SnapshotTesting.framework in Frameworks */,
+				C305AC4208160CFF487FD25B1A5DA2FB /* Html.framework in Frameworks */,
+				22D4EFC4BB4A144D74447015A3508FD8 /* SnapshotTesting.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_EF54AFAC47518D12545D96B0009E1B06 /* Frameworks */ = {
+		659C534233B93C8235AFAA487DAC4C6E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_D1EC6634E48CAA46F330C4A722EC0337 /* Html.framework in Frameworks */,
-				BF_24ED05C03DAFDF39FE30EE14FFE8730E /* SnapshotTesting.framework in Frameworks */,
+				DC0BE7BC69BB026C7C04105CEDDD7902 /* Html.framework in Frameworks */,
+				E5D009555297E3FA942F0CC1F2E1C7FC /* SnapshotTesting.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_F410FBAE321CF304B1EA2ED065EB598F /* Frameworks */ = {
+		B4D802C5E7E40EE93E15D7F32DF224CB /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_B6E12040B2F4655609A10C1FEC7F37C2 /* HtmlSnapshotTesting.framework in Frameworks */,
+				BAE3237DCE9A0E30E5D34F994C0405E9 /* Html.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_FA223CB757A14CF5B4B47E9BE5576A3E /* Frameworks */ = {
+		BB9BAD940E8E9CEE516D2025D87FB86E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_70B4D5132D2605928522D2B6D09331DB /* Html.framework in Frameworks */,
+				320F85D14E26D20C47FD2167B68B7B45 /* HtmlSnapshotTesting.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_FD3661420DA129DE351BA7539944A4BD /* Frameworks */ = {
+		D136236D840663603B9871C6D364F48D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_2B257D3CB2E9B81C247ADF381DBDB62B /* HtmlSnapshotTesting.framework in Frameworks */,
+				9597C5A3B84198D3A377022953A8A4D7 /* Html.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		G_055F07B9BA227AC03E30801B449E86C8 /* HtmlSnapshotTesting */ = {
+		1AEBCCA16A4DC85E3309C6F83C874D4C /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				FR_2C04ED2D80670BFA8174C411C3DCC50B /* HtmlSnapshotTesting.swift */,
+				9E126A3CA355B25D21B2623F839076B9 /* Html.framework */,
+				3B34F431D275160E7E8731AAD1D6A329 /* Html.framework */,
+				B4B440160381819677F8C69057C87D11 /* Html.framework */,
+				AB046D1C05F47D3AD9B2CAE7CBD4F577 /* Html.framework */,
+				F74E777DD008915447BBB102F893ED38 /* HtmlSnapshotTesting.framework */,
+				E46CB2B107F502CC7E8D939854F0D9CB /* HtmlSnapshotTesting.framework */,
+				CCC4F55894F2A87CC63B036B604930DC /* HtmlSnapshotTesting.framework */,
+				F1CBC16061375C51FBFB40C4BEAED518 /* HtmlSnapshotTestingTests.xctest */,
+				05BD2B8FDAC04D4E797449823E9C94AB /* HtmlSnapshotTestingTests.xctest */,
+				FC64ED50B6E4126DFEAC21391EE00590 /* HtmlSnapshotTestingTests.xctest */,
+				B3E3F6B828962116F3E9C05DAF1FB06C /* HtmlTests.xctest */,
+				9765C9A1F174B7B2CFB9E078325F971F /* HtmlTests.xctest */,
+				46849DCB7BA41A018AB4F4CACB5D9E45 /* HtmlTests.xctest */,
+				0A94FF60072BECC2CA97CA8C647A8D43 /* HtmlTests.xctest */,
 			);
-			name = HtmlSnapshotTesting;
-			path = Sources/HtmlSnapshotTesting;
+			name = Products;
 			sourceTree = "<group>";
 		};
-		G_14F4C555950B9F930064EDCCC39A6660 /* HtmlTests */ = {
+		40B1829E07256C0C84102560336586B0 /* Html */ = {
 			isa = PBXGroup;
 			children = (
-				FR_EF813CC7FA4018FC2F9A50D2931DDA13 /* AriaTests.swift */,
-				FR_C37C9D4A3478D7A0906676B07410B4F5 /* AttributesTests.swift */,
-				FR_AF1B21A15DC5D681508C766490919BD1 /* ElementsTests.swift */,
-				FR_5B2816E603A1B4A51D2410FE860B6A73 /* EventsTests.swift */,
-				FR_FD4A0701B482ECFD3AC801193749B828 /* MediaTypeTests.swift */,
-				FR_DCB027799D18D0FB625BD4612E72FAC3 /* XCTestManifests.swift */,
-			);
-			name = HtmlTests;
-			path = Tests/HtmlTests;
-			sourceTree = "<group>";
-		};
-		G_7C7209BCC2391F524DE3FE11C5DD57A4 /* Html */ = {
-			isa = PBXGroup;
-			children = (
-				FR_B83D9298FE6176D48170EF3E46F99CCA /* Aria.swift */,
-				FR_75E1F23756D2E133BA75C9CE7559FED4 /* Attributes.swift */,
-				FR_40794F1143674CDA249455CEE44CF36F /* ChildOf.swift */,
-				FR_0850AEA78BCAAD1DA3F3C266E13B78CB /* DebugRender.swift */,
-				FR_3AEC4DC02DA3D43270FEA9438A693C40 /* Elements.swift */,
-				FR_D02E69C3123E18DA31C95CCEF4F55FD0 /* Events.swift */,
-				FR_84247EDD4C722F051D26423EAF9556B4 /* Html4.swift */,
-				FR_2773FDC63ECF9CA8CE40879B3B0EACC4 /* MediaType.swift */,
-				FR_0F4D9E9DED7F8875C991F2C8D340AC0F /* Node.swift */,
-				FR_F23919B43A726458B14604B66DD07753 /* Render.swift */,
-				FR_1A5D33291C6AFD143674D746942B98C4 /* Tag.swift */,
+				DD134F1DBDA964CE05DF7C22ACA72A49 /* Aria.swift */,
+				F28E121F5FC3715428AEEA82FC5F98FD /* Attributes.swift */,
+				B8C9046535B58D48C7C30DB39E006A8E /* ChildOf.swift */,
+				369859355DF7EFF616957797418CA39A /* DebugRender.swift */,
+				6B71DD55BD5D66D1EA732D28BD0BE6E9 /* Elements.swift */,
+				0E4BCE93E0F76CBEC0BD72AE17F41267 /* Events.swift */,
+				6618A20707AF30DE9D556FA2DC9E7739 /* Html4.swift */,
+				7BDAF91C40D03C3A7E69A8BBFD69EC8D /* MediaType.swift */,
+				115C2537BD6C462339847B6D06893956 /* Node.swift */,
+				8AA45861B39F4E37CDDDCCABB2A53A1E /* Render.swift */,
+				5513765DDE12320E99FB4423D8117DEB /* Tag.swift */,
 			);
 			name = Html;
 			path = Sources/Html;
 			sourceTree = "<group>";
 		};
-		G_8F3F972CC52F24124E9996A4ABCD0256 /* Products */ = {
+		574CD0AB03DA8D1C2FE90EDAE59326B8 /* HtmlTests */ = {
 			isa = PBXGroup;
 			children = (
-				FR_454B7862EFAF417284E587FDE4F417F7 /* Html.framework */,
-				FR_56BF69D04F58D631B62547910FBA29AB /* Html.framework */,
-				FR_137ABCB525F73E48E9E0329EC90064AF /* Html.framework */,
-				FR_A851F66F18D71D07E129E4B1177B980C /* Html.framework */,
-				FR_5C5B2F5B06548979136A244E4C89D95A /* HtmlSnapshotTesting.framework */,
-				FR_0738B551A3F66674027ADC5E96FB6433 /* HtmlSnapshotTesting.framework */,
-				FR_D0E4DB97B85C77E83808CFAA36086DFC /* HtmlSnapshotTesting.framework */,
-				FR_4024F32C566BA88E351F72CADE1F9287 /* HtmlSnapshotTestingTests.xctest */,
-				FR_426253E0818C46FC1DB97614AD713830 /* HtmlSnapshotTestingTests.xctest */,
-				FR_60FE2FD7DED430CDB41B57A0CAECD79A /* HtmlSnapshotTestingTests.xctest */,
-				FR_186C495A13918FA9B6DC64977C0BEF84 /* HtmlTests.xctest */,
-				FR_44D3298F923225BC3162818D9F543BBC /* HtmlTests.xctest */,
-				FR_87FEDF3B848906588C41DBE9A6F6E75E /* HtmlTests.xctest */,
-				FR_207D0187D4F8218348DEFA383C2B838C /* HtmlTests.xctest */,
+				A8A9352E08F9F5B85DD11E79B811B73B /* AriaTests.swift */,
+				CAC51C18E3303316FFBD4A3A9EF5BFA9 /* AttributesTests.swift */,
+				4DC7C33F80B9F9085D9ECAF42D6F16B0 /* ElementsTests.swift */,
+				E54612F8B09ADB7F65E64E0560CA4788 /* EventsTests.swift */,
+				708E8F50973AA5115D39081C8C682A7A /* MediaTypeTests.swift */,
+				3D9DCA8DE3E7090A3C282A73883D7442 /* XCTestManifests.swift */,
 			);
-			name = Products;
+			name = HtmlTests;
+			path = Tests/HtmlTests;
 			sourceTree = "<group>";
 		};
-		G_B5AF402179CC9352B7B9EC1CD290D43A /* Frameworks */ = {
+		93C11F768DCD7665DDF54E09BEA33FB1 = {
 			isa = PBXGroup;
 			children = (
-				FR_5D868222BE76AE04E2B491E967A6F5F9 /* SnapshotTesting.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		G_B6EC796527F6FA1903AF2C18A2BFDA2D = {
-			isa = PBXGroup;
-			children = (
-				G_7C7209BCC2391F524DE3FE11C5DD57A4 /* Html */,
-				G_055F07B9BA227AC03E30801B449E86C8 /* HtmlSnapshotTesting */,
-				G_D105CECB23944DD92E02879650FA8915 /* HtmlSnapshotTestingTests */,
-				G_14F4C555950B9F930064EDCCC39A6660 /* HtmlTests */,
-				G_B5AF402179CC9352B7B9EC1CD290D43A /* Frameworks */,
-				G_8F3F972CC52F24124E9996A4ABCD0256 /* Products */,
+				40B1829E07256C0C84102560336586B0 /* Html */,
+				E98CFB2A7839E2F351190C0F95CD2803 /* HtmlSnapshotTesting */,
+				CC9B6CA3FFCDE3D6AAFD4888308DCCC2 /* HtmlSnapshotTestingTests */,
+				574CD0AB03DA8D1C2FE90EDAE59326B8 /* HtmlTests */,
+				95FA088E7B3CC74727CE5A20CA842868 /* Frameworks */,
+				1AEBCCA16A4DC85E3309C6F83C874D4C /* Products */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
 			tabWidth = 2;
 			usesTabs = 0;
 		};
-		G_D105CECB23944DD92E02879650FA8915 /* HtmlSnapshotTestingTests */ = {
+		95FA088E7B3CC74727CE5A20CA842868 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				FR_705A9DFC1E550226909432DCEE159048 /* HtmlSnapshotTestingTests.swift */,
-				FR_58555AFF1E96E4DE4F51D747882EF806 /* XCTestManifests.swift */,
+				A7CCBDB5117940D470A385FB24A2F061 /* SnapshotTesting.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		CC9B6CA3FFCDE3D6AAFD4888308DCCC2 /* HtmlSnapshotTestingTests */ = {
+			isa = PBXGroup;
+			children = (
+				88A8D435A245A1B388B6B9DCA4C85450 /* HtmlSnapshotTestingTests.swift */,
+				417A595A39394207A53E54ACAD07FB15 /* XCTestManifests.swift */,
 			);
 			name = HtmlSnapshotTestingTests;
 			path = Tests/HtmlSnapshotTestingTests;
 			sourceTree = "<group>";
 		};
+		E98CFB2A7839E2F351190C0F95CD2803 /* HtmlSnapshotTesting */ = {
+			isa = PBXGroup;
+			children = (
+				27254C973FAFC7DBB8BF87EC41C30E53 /* HtmlSnapshotTesting.swift */,
+			);
+			name = HtmlSnapshotTesting;
+			path = Sources/HtmlSnapshotTesting;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		NT_0EC5D5A0415352CD656BDFBBA012F05F /* HtmlTests_macOS */ = {
+		10893907EC7EE4BFA378F918CAC99DFE /* HtmlSnapshotTestingTests_macOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_22C0E5C81ECB635472569EFFEA8319DA /* Build configuration list for PBXNativeTarget "HtmlTests_macOS" */;
+			buildConfigurationList = 00429DAA9AA8FF808E618D2C67850C2D /* Build configuration list for PBXNativeTarget "HtmlSnapshotTestingTests_macOS" */;
 			buildPhases = (
-				SBP_BDBEA8231C20424E064DFB597FF52461 /* Sources */,
-				FBP_A1466079479EC0AA7AB058D9EDB8F234 /* Frameworks */,
-				CFBP_454D57A9593439E7D0AA015E804AF1A5 /* Embed Frameworks */,
+				630338A7D1776A06167A0C971FF8260C /* Sources */,
+				390B06E86D5FD376E5E7C443F109999C /* Frameworks */,
+				9DFFFD731E4FD8472D8F2C29A36A7643 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				TD_E602C0A4C47944650BECE537C914501F /* PBXTargetDependency */,
-			);
-			name = HtmlTests_macOS;
-			productName = HtmlTests_macOS;
-			productReference = FR_44D3298F923225BC3162818D9F543BBC /* HtmlTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		NT_2AB5827BD5D16BFB6725C893076C6FDF /* HtmlSnapshotTestingTests_macOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_905577B2B1F7F177BEA37911480E6682 /* Build configuration list for PBXNativeTarget "HtmlSnapshotTestingTests_macOS" */;
-			buildPhases = (
-				SBP_486634345880070F81FF70A14535A014 /* Sources */,
-				FBP_2C81E5F0230FB12D799B2A24DA3E8879 /* Frameworks */,
-				CFBP_6BAA655AFDC030DC4A415B276A855D49 /* Embed Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				TD_F7539E2170D052FD165B3CC230B5158A /* PBXTargetDependency */,
+				C649DCC9019B845AE101C9473E5D62D4 /* PBXTargetDependency */,
 			);
 			name = HtmlSnapshotTestingTests_macOS;
 			productName = HtmlSnapshotTestingTests_macOS;
-			productReference = FR_426253E0818C46FC1DB97614AD713830 /* HtmlSnapshotTestingTests.xctest */;
+			productReference = 05BD2B8FDAC04D4E797449823E9C94AB /* HtmlSnapshotTestingTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		NT_2DC28C2207FB2259D050202830AD64D1 /* HtmlSnapshotTestingTests_iOS */ = {
+		2BA1D0CC8309950F649BDD13CBCDE39B /* HtmlSnapshotTesting_tvOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_E03EA63DE9CCFC9DEB988DC5AFBAFE8B /* Build configuration list for PBXNativeTarget "HtmlSnapshotTestingTests_iOS" */;
+			buildConfigurationList = CBC7217548F04660792C50F0638E8D9D /* Build configuration list for PBXNativeTarget "HtmlSnapshotTesting_tvOS" */;
 			buildPhases = (
-				SBP_A9AE976A15137D14C488BEC51ECDBF90 /* Sources */,
-				FBP_F410FBAE321CF304B1EA2ED065EB598F /* Frameworks */,
-				CFBP_104F460684C31F51F582A752718D1F52 /* Embed Frameworks */,
+				BD0797055DCB975FD9EA5BAE65D1E0D8 /* Sources */,
+				5A5D749546946AF2686829C2088C0A4D /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				TD_C0C3B9066E9270D13A89F7D4C20CB09E /* PBXTargetDependency */,
+				096DC36E3B64481A20755245060DB29B /* PBXTargetDependency */,
 			);
-			name = HtmlSnapshotTestingTests_iOS;
-			productName = HtmlSnapshotTestingTests_iOS;
-			productReference = FR_4024F32C566BA88E351F72CADE1F9287 /* HtmlSnapshotTestingTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		NT_35F4D7F166DB6BD11B0FE52D126BA796 /* HtmlSnapshotTesting_macOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_D6C7C63AF6E329A40C69B9B62FBBCB36 /* Build configuration list for PBXNativeTarget "HtmlSnapshotTesting_macOS" */;
-			buildPhases = (
-				SBP_C66B6CCD8E3EA8559C1A36AE952A277E /* Sources */,
-				FBP_EF54AFAC47518D12545D96B0009E1B06 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				TD_3D83B190D0212792CDFDDA92671C94AF /* PBXTargetDependency */,
-			);
-			name = HtmlSnapshotTesting_macOS;
-			productName = HtmlSnapshotTesting_macOS;
-			productReference = FR_0738B551A3F66674027ADC5E96FB6433 /* HtmlSnapshotTesting.framework */;
+			name = HtmlSnapshotTesting_tvOS;
+			productName = HtmlSnapshotTesting_tvOS;
+			productReference = CCC4F55894F2A87CC63B036B604930DC /* HtmlSnapshotTesting.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		NT_391C0E1A822D646F708827B001EB83D2 /* Html_iOS */ = {
+		387DD84FD9EB67768EA91AEA30999728 /* Html_macOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_A4FAD437AF76FDBA9E3C49D474751D14 /* Build configuration list for PBXNativeTarget "Html_iOS" */;
+			buildConfigurationList = 7361D4AFE8C29EE405C39A6ECC7D4C81 /* Build configuration list for PBXNativeTarget "Html_macOS" */;
 			buildPhases = (
-				SBP_2C92153816399A81B710EA9670C185ED /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = Html_iOS;
-			productName = Html_iOS;
-			productReference = FR_454B7862EFAF417284E587FDE4F417F7 /* Html.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		NT_3DAB1392843626D3536CA19914B502C8 /* Html_macOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_A5BF7EDA76AE6BC08855C7AC43201B90 /* Build configuration list for PBXNativeTarget "Html_macOS" */;
-			buildPhases = (
-				SBP_76E5A454BAA5945F6970AF64320FD788 /* Sources */,
+				F7F9AFA0D7E961D4D57D2A2969DFA4DE /* Sources */,
 			);
 			buildRules = (
 			);
@@ -581,99 +530,85 @@
 			);
 			name = Html_macOS;
 			productName = Html_macOS;
-			productReference = FR_56BF69D04F58D631B62547910FBA29AB /* Html.framework */;
+			productReference = 3B34F431D275160E7E8731AAD1D6A329 /* Html.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		NT_5881CD49A13FAFE4B62A050F5942B296 /* HtmlSnapshotTesting_iOS */ = {
+		39FAF90AB05CB37935D4204A5BE017B8 /* HtmlTests_tvOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_945B5094C88A155540D2897E5A7EA6EC /* Build configuration list for PBXNativeTarget "HtmlSnapshotTesting_iOS" */;
+			buildConfigurationList = 34356219C5D498565F2E29C6AD1A10F8 /* Build configuration list for PBXNativeTarget "HtmlTests_tvOS" */;
 			buildPhases = (
-				SBP_A3115C515AF6943CB3FB42249EF1B84D /* Sources */,
-				FBP_DC02A60B50A5C4A75A5DF850DFAABFBB /* Frameworks */,
+				F71BFDDC67E75BBB8154F58EFB543078 /* Sources */,
+				34A8E9EF520920AF1AB0B706E6D3E5DC /* Frameworks */,
+				90ECE35850EFF663540570E5F54135BA /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				TD_A8D1AB9B9D218884B7DEA066200142E4 /* PBXTargetDependency */,
+				08B06CA02522562C0AAA711791676570 /* PBXTargetDependency */,
+			);
+			name = HtmlTests_tvOS;
+			productName = HtmlTests_tvOS;
+			productReference = 46849DCB7BA41A018AB4F4CACB5D9E45 /* HtmlTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		6A73DBC9B9DB85707C2C0821F55D62C4 /* HtmlSnapshotTestingTests_iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4375A851BEE667A5BE8463A368490AA3 /* Build configuration list for PBXNativeTarget "HtmlSnapshotTestingTests_iOS" */;
+			buildPhases = (
+				DAA9ED07754E89A1D9F2FD42FBBC7759 /* Sources */,
+				BB9BAD940E8E9CEE516D2025D87FB86E /* Frameworks */,
+				1A46D042D093C8DAA19EB88DDF04DBE6 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D3C289FC62F3195C67F426E168E932DC /* PBXTargetDependency */,
+			);
+			name = HtmlSnapshotTestingTests_iOS;
+			productName = HtmlSnapshotTestingTests_iOS;
+			productReference = F1CBC16061375C51FBFB40C4BEAED518 /* HtmlSnapshotTestingTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		774558CB50D4BB2B0629975BADF641CA /* HtmlTests_watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1D3FFC21A2629F546BB403453C20481B /* Build configuration list for PBXNativeTarget "HtmlTests_watchOS" */;
+			buildPhases = (
+				FA3D6956ED335EE81F901EBC98E5B1EF /* Sources */,
+				D136236D840663603B9871C6D364F48D /* Frameworks */,
+				F1A7E8AA26346DB89C3B78EEE9C87877 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				8ED14E7F682D100C424BC56EC920EC87 /* PBXTargetDependency */,
+			);
+			name = HtmlTests_watchOS;
+			productName = HtmlTests_watchOS;
+			productReference = 0A94FF60072BECC2CA97CA8C647A8D43 /* HtmlTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		83770D5D7E5A47BE568F39AD0B92F45D /* HtmlSnapshotTesting_iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 02CFF7F8DCCEC1A27465872E5109FAD3 /* Build configuration list for PBXNativeTarget "HtmlSnapshotTesting_iOS" */;
+			buildPhases = (
+				1AD71F9750F1D5CCADD82CDD47FF3C11 /* Sources */,
+				659C534233B93C8235AFAA487DAC4C6E /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				79E57862C51E2B55B0EC5D60CAD07151 /* PBXTargetDependency */,
 			);
 			name = HtmlSnapshotTesting_iOS;
 			productName = HtmlSnapshotTesting_iOS;
-			productReference = FR_5C5B2F5B06548979136A244E4C89D95A /* HtmlSnapshotTesting.framework */;
+			productReference = F74E777DD008915447BBB102F893ED38 /* HtmlSnapshotTesting.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		NT_8DA0D6B0D3FB381C06CED88C8D8EB1F3 /* HtmlSnapshotTesting_tvOS */ = {
+		875B8C7FB1A8896A28D7B853F513CFD6 /* Html_tvOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_FEE21409DFDDCFEB1780816ECBFD3E12 /* Build configuration list for PBXNativeTarget "HtmlSnapshotTesting_tvOS" */;
+			buildConfigurationList = 74A6985BA841A6B69A009881679995BD /* Build configuration list for PBXNativeTarget "Html_tvOS" */;
 			buildPhases = (
-				SBP_1F3FBCFBA16642D7EE34F01C3D6457E9 /* Sources */,
-				FBP_E22C0A1C815DBF1E5E42519734360A4D /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				TD_5E1A3F9667CA86E021E68F13E2F22782 /* PBXTargetDependency */,
-			);
-			name = HtmlSnapshotTesting_tvOS;
-			productName = HtmlSnapshotTesting_tvOS;
-			productReference = FR_D0E4DB97B85C77E83808CFAA36086DFC /* HtmlSnapshotTesting.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		NT_A56629B8583F524D8DABDEB1B3B5FCB8 /* Html_watchOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_36D42AC3DE4FF6C0C91AA27CB7BED96F /* Build configuration list for PBXNativeTarget "Html_watchOS" */;
-			buildPhases = (
-				SBP_E1D26DE47F8EEA9DE0C71207A87F5144 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = Html_watchOS;
-			productName = Html_watchOS;
-			productReference = FR_A851F66F18D71D07E129E4B1177B980C /* Html.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		NT_C8AB64528B429FF8C5E983E839B1E0BE /* HtmlTests_iOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_2AAD18E374F68D92C2AF3F10876697CF /* Build configuration list for PBXNativeTarget "HtmlTests_iOS" */;
-			buildPhases = (
-				SBP_8B65B522274C0FC6C8C3436FB0CDF9A4 /* Sources */,
-				FBP_3E0B8227123B1F3E772E515DEF4E5ED7 /* Frameworks */,
-				CFBP_0EF97FE9237F775F6378EF6C8ADDF746 /* Embed Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				TD_2D2E8D0C8BA27FBFC8FAC0E588D034AE /* PBXTargetDependency */,
-			);
-			name = HtmlTests_iOS;
-			productName = HtmlTests_iOS;
-			productReference = FR_186C495A13918FA9B6DC64977C0BEF84 /* HtmlTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		NT_DD09D77AEA211941B06E7B13605F9DF1 /* HtmlSnapshotTestingTests_tvOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_D99A9344C8A0D2283BC48B784B8AB7F5 /* Build configuration list for PBXNativeTarget "HtmlSnapshotTestingTests_tvOS" */;
-			buildPhases = (
-				SBP_B203030E5BF0C799FAEF12719C2CDCDE /* Sources */,
-				FBP_FD3661420DA129DE351BA7539944A4BD /* Frameworks */,
-				CFBP_ED3D783EB6C94698CCB70104EB35CB95 /* Embed Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				TD_CB8FE0FEB7D30203E7807BF9E99CBF37 /* PBXTargetDependency */,
-			);
-			name = HtmlSnapshotTestingTests_tvOS;
-			productName = HtmlSnapshotTestingTests_tvOS;
-			productReference = FR_60FE2FD7DED430CDB41B57A0CAECD79A /* HtmlSnapshotTestingTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		NT_E3DC39F33A9CC5CE33CBED0C7A0716AB /* Html_tvOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_1CD299291AE0BFFA37367999CEB6F900 /* Build configuration list for PBXNativeTarget "Html_tvOS" */;
-			buildPhases = (
-				SBP_02B92F45DAD4060A3E2D98ADBC952D28 /* Sources */,
+				4BCFFE4691CFC55C997B911AC1A05B80 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -681,315 +616,466 @@
 			);
 			name = Html_tvOS;
 			productName = Html_tvOS;
-			productReference = FR_137ABCB525F73E48E9E0329EC90064AF /* Html.framework */;
+			productReference = B4B440160381819677F8C69057C87D11 /* Html.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		NT_E3FE8A7E649940DA2207FA60E84BE68D /* HtmlTests_tvOS */ = {
+		9D4E25C5088CA6D3CA55EC77E0EDCA7D /* HtmlSnapshotTesting_macOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_035E70787F58B7A45E9C0CA167594798 /* Build configuration list for PBXNativeTarget "HtmlTests_tvOS" */;
+			buildConfigurationList = DE53FB1A8938E18AF7785B4971EF5C05 /* Build configuration list for PBXNativeTarget "HtmlSnapshotTesting_macOS" */;
 			buildPhases = (
-				SBP_3B2888382ADFB09FB3468DEC2CB74839 /* Sources */,
-				FBP_FA223CB757A14CF5B4B47E9BE5576A3E /* Frameworks */,
-				CFBP_3518DAB421FD09511C350B2070048EC1 /* Embed Frameworks */,
+				C58F7FD5230AD178954BB65CDC889C2B /* Sources */,
+				21F8685660D3998ACC35B487A6BB70D4 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				TD_DCE99D0564E79A0C1CB788A94337CCD0 /* PBXTargetDependency */,
+				110288077A8ABC1833459AA18BA8EC6D /* PBXTargetDependency */,
 			);
-			name = HtmlTests_tvOS;
-			productName = HtmlTests_tvOS;
-			productReference = FR_87FEDF3B848906588C41DBE9A6F6E75E /* HtmlTests.xctest */;
+			name = HtmlSnapshotTesting_macOS;
+			productName = HtmlSnapshotTesting_macOS;
+			productReference = E46CB2B107F502CC7E8D939854F0D9CB /* HtmlSnapshotTesting.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		B641E0069847CD6E1B6AC66EFDFE23AC /* HtmlTests_iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C2A2AA3B6C1FE18F4E5F56B9C2733E72 /* Build configuration list for PBXNativeTarget "HtmlTests_iOS" */;
+			buildPhases = (
+				39F5345D8E9F5907F5C54CF36A03BF9A /* Sources */,
+				B4D802C5E7E40EE93E15D7F32DF224CB /* Frameworks */,
+				C80455EA9C5211ED801825B5F017B178 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				486F5CB76FB61F3395056F95714F007A /* PBXTargetDependency */,
+			);
+			name = HtmlTests_iOS;
+			productName = HtmlTests_iOS;
+			productReference = B3E3F6B828962116F3E9C05DAF1FB06C /* HtmlTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		NT_FA846A49F72C052E4C6D4EB6DDB7C485 /* HtmlTests_watchOS */ = {
+		C9276D931EC24AE11A4283A3A36DFE84 /* HtmlTests_macOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_07248284D902B7D116DF9C8019E8BD7B /* Build configuration list for PBXNativeTarget "HtmlTests_watchOS" */;
+			buildConfigurationList = F27C702E5A3143E744B5E29F2851DEE3 /* Build configuration list for PBXNativeTarget "HtmlTests_macOS" */;
 			buildPhases = (
-				SBP_8028A7936CB50E1A22E94C3DC34A1FE7 /* Sources */,
-				FBP_29AA1172FF0196656995D067990E362F /* Frameworks */,
-				CFBP_F4A017195DD6933F2FEC397593218ECD /* Embed Frameworks */,
+				E33F8653E7AC64501EAB9A33CD1CE86F /* Sources */,
+				5058F16FF516A6E11453F0890D8A0571 /* Frameworks */,
+				D8CF69C6326F606601570C2C4DC9B81A /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				TD_806B692C992C010CFFF126117B2E0E05 /* PBXTargetDependency */,
+				66EED7EC4D65FE5BE48E9F0026BA717C /* PBXTargetDependency */,
 			);
-			name = HtmlTests_watchOS;
-			productName = HtmlTests_watchOS;
-			productReference = FR_207D0187D4F8218348DEFA383C2B838C /* HtmlTests.xctest */;
+			name = HtmlTests_macOS;
+			productName = HtmlTests_macOS;
+			productReference = 9765C9A1F174B7B2CFB9E078325F971F /* HtmlTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		D66EE4CDA1674BC198B4235AA4485515 /* HtmlSnapshotTestingTests_tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 205C554E125845FED588DF6CD8D273ED /* Build configuration list for PBXNativeTarget "HtmlSnapshotTestingTests_tvOS" */;
+			buildPhases = (
+				1ACDCB10270FD6EEE71A5A160A73BB3D /* Sources */,
+				268237254571CC5A45FB6AB774D4C5C6 /* Frameworks */,
+				51009AB3649DC6CF3191530574D11E6B /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1735ED5D490B44E819CB1F92C9B378F4 /* PBXTargetDependency */,
+			);
+			name = HtmlSnapshotTestingTests_tvOS;
+			productName = HtmlSnapshotTestingTests_tvOS;
+			productReference = FC64ED50B6E4126DFEAC21391EE00590 /* HtmlSnapshotTestingTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		ECF3589FFC8B598E275967EA4DCE9E99 /* Html_watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7B27AF6FECA51D0A3D4993DD5D2EC94D /* Build configuration list for PBXNativeTarget "Html_watchOS" */;
+			buildPhases = (
+				DBB4B9616E2386CE9D5DC982651E5CB2 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Html_watchOS;
+			productName = Html_watchOS;
+			productReference = AB046D1C05F47D3AD9B2CAE7CBD4F577 /* Html.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		F810FEAA71B0586D1B6CE7F412FF7D3E /* Html_iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9DDE14C3A0616AD73B6D3127882BB161 /* Build configuration list for PBXNativeTarget "Html_iOS" */;
+			buildPhases = (
+				E8468F6DB380878420593ADF957BD754 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Html_iOS;
+			productName = Html_iOS;
+			productReference = 9E126A3CA355B25D21B2623F839076B9 /* Html.framework */;
+			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		P_71156FC3BAF7CC8140053AE66992A365 /* Project object */ = {
+		CFEA2F996BC045811F1828EEFB911A38 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1000;
 			};
-			buildConfigurationList = CL_728CA9104A9BA70AFD0D66631D9B25E2 /* Build configuration list for PBXProject "Html" */;
-			compatibilityVersion = "Xcode 3.2";
+			buildConfigurationList = 09327A61B6F3295CFE5674279D1955FC /* Build configuration list for PBXProject "Html" */;
+			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 			);
-			mainGroup = G_B6EC796527F6FA1903AF2C18A2BFDA2D;
+			mainGroup = 93C11F768DCD7665DDF54E09BEA33FB1;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				NT_2DC28C2207FB2259D050202830AD64D1 /* HtmlSnapshotTestingTests_iOS */,
-				NT_2AB5827BD5D16BFB6725C893076C6FDF /* HtmlSnapshotTestingTests_macOS */,
-				NT_DD09D77AEA211941B06E7B13605F9DF1 /* HtmlSnapshotTestingTests_tvOS */,
-				NT_5881CD49A13FAFE4B62A050F5942B296 /* HtmlSnapshotTesting_iOS */,
-				NT_35F4D7F166DB6BD11B0FE52D126BA796 /* HtmlSnapshotTesting_macOS */,
-				NT_8DA0D6B0D3FB381C06CED88C8D8EB1F3 /* HtmlSnapshotTesting_tvOS */,
-				NT_C8AB64528B429FF8C5E983E839B1E0BE /* HtmlTests_iOS */,
-				NT_0EC5D5A0415352CD656BDFBBA012F05F /* HtmlTests_macOS */,
-				NT_E3FE8A7E649940DA2207FA60E84BE68D /* HtmlTests_tvOS */,
-				NT_FA846A49F72C052E4C6D4EB6DDB7C485 /* HtmlTests_watchOS */,
-				NT_391C0E1A822D646F708827B001EB83D2 /* Html_iOS */,
-				NT_3DAB1392843626D3536CA19914B502C8 /* Html_macOS */,
-				NT_E3DC39F33A9CC5CE33CBED0C7A0716AB /* Html_tvOS */,
-				NT_A56629B8583F524D8DABDEB1B3B5FCB8 /* Html_watchOS */,
+				6A73DBC9B9DB85707C2C0821F55D62C4 /* HtmlSnapshotTestingTests_iOS */,
+				10893907EC7EE4BFA378F918CAC99DFE /* HtmlSnapshotTestingTests_macOS */,
+				D66EE4CDA1674BC198B4235AA4485515 /* HtmlSnapshotTestingTests_tvOS */,
+				83770D5D7E5A47BE568F39AD0B92F45D /* HtmlSnapshotTesting_iOS */,
+				9D4E25C5088CA6D3CA55EC77E0EDCA7D /* HtmlSnapshotTesting_macOS */,
+				2BA1D0CC8309950F649BDD13CBCDE39B /* HtmlSnapshotTesting_tvOS */,
+				B641E0069847CD6E1B6AC66EFDFE23AC /* HtmlTests_iOS */,
+				C9276D931EC24AE11A4283A3A36DFE84 /* HtmlTests_macOS */,
+				39FAF90AB05CB37935D4204A5BE017B8 /* HtmlTests_tvOS */,
+				774558CB50D4BB2B0629975BADF641CA /* HtmlTests_watchOS */,
+				F810FEAA71B0586D1B6CE7F412FF7D3E /* Html_iOS */,
+				387DD84FD9EB67768EA91AEA30999728 /* Html_macOS */,
+				875B8C7FB1A8896A28D7B853F513CFD6 /* Html_tvOS */,
+				ECF3589FFC8B598E275967EA4DCE9E99 /* Html_watchOS */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		SBP_02B92F45DAD4060A3E2D98ADBC952D28 /* Sources */ = {
+		1ACDCB10270FD6EEE71A5A160A73BB3D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_2FACF8DC1A08D554CABA3211CB6CA8CD /* Aria.swift in Sources */,
-				BF_605F312BFAC83F9D1E3AA65CB1668889 /* Attributes.swift in Sources */,
-				BF_050A434EB48E3A85149CA2DC1947E934 /* ChildOf.swift in Sources */,
-				BF_7B73670CF0825E7E4B35B4754EA0177B /* DebugRender.swift in Sources */,
-				BF_AA00EED8F7444475555C9CC04A91796A /* Elements.swift in Sources */,
-				BF_167EC013FBB3444EB137981C73CB1087 /* Events.swift in Sources */,
-				BF_15A7BDEBF65A443739634DB5C582FC81 /* Html4.swift in Sources */,
-				BF_EF48C76BDF60C8580D714F851E5D88B0 /* MediaType.swift in Sources */,
-				BF_C26E0033107220651F282052426503F6 /* Node.swift in Sources */,
-				BF_46DD45E6A6D9ED65D8141EAD3EA343F8 /* Render.swift in Sources */,
-				BF_6861570A1AAB9862DA92C933E5EFCF37 /* Tag.swift in Sources */,
+				4CB4376B42DA8FCCFA23B0EEADD8BFA5 /* HtmlSnapshotTestingTests.swift in Sources */,
+				DCEDD7692E68C69E9001FCD352B4941E /* XCTestManifests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_1F3FBCFBA16642D7EE34F01C3D6457E9 /* Sources */ = {
+		1AD71F9750F1D5CCADD82CDD47FF3C11 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_565393F81601512D2C6E41DCE7572D1D /* HtmlSnapshotTesting.swift in Sources */,
+				55136F7ABEA6B6E95DF69567D1484A0B /* HtmlSnapshotTesting.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_2C92153816399A81B710EA9670C185ED /* Sources */ = {
+		39F5345D8E9F5907F5C54CF36A03BF9A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_1594ED178D46E0C388251F1E04CDE923 /* Aria.swift in Sources */,
-				BF_55946568BD6A7CDF27D4FA633035BD5B /* Attributes.swift in Sources */,
-				BF_39A0B61DCD052204E4318C17B056F7A9 /* ChildOf.swift in Sources */,
-				BF_8825CC811E0A3040695CBDACCAA3C14F /* DebugRender.swift in Sources */,
-				BF_F3DFC44A453A05F52FC0E68020D84D5B /* Elements.swift in Sources */,
-				BF_2BA1B815F9EC78F22E1CCECFAEE5E44F /* Events.swift in Sources */,
-				BF_B310E9EAD20812D893E237231E3DA4D2 /* Html4.swift in Sources */,
-				BF_B2F122C85B8CCF9825F3D203EE89A3C9 /* MediaType.swift in Sources */,
-				BF_B6432B24DA58EB3438142CB65615E1D0 /* Node.swift in Sources */,
-				BF_FFADB3958F2E3230AE1E012A0E69DC6A /* Render.swift in Sources */,
-				BF_3F99220FA6DA04A3EBC7BE4A4A1B116B /* Tag.swift in Sources */,
+				0115EB8F32DBE433E1050DA098737BE0 /* AriaTests.swift in Sources */,
+				88805D464199C4C7FAF291745ECAAD63 /* AttributesTests.swift in Sources */,
+				1BE39F74F999E0822E97F961D75C8216 /* ElementsTests.swift in Sources */,
+				83A3863FABFA08DDD2330E2A0D1DA364 /* EventsTests.swift in Sources */,
+				B5B05E827B38F5AD3B7D100CB53449FC /* MediaTypeTests.swift in Sources */,
+				BB979161058B8200CC85CEB775E17EF8 /* XCTestManifests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_3B2888382ADFB09FB3468DEC2CB74839 /* Sources */ = {
+		4BCFFE4691CFC55C997B911AC1A05B80 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_D164F90CEF6B6A5A9B50B0E4C819B853 /* AriaTests.swift in Sources */,
-				BF_24991B811CB7C11D52836CDBB9738D91 /* AttributesTests.swift in Sources */,
-				BF_26D7F20A75ED76315AAC9B5C41D718BC /* ElementsTests.swift in Sources */,
-				BF_A88105ED0725F34B1052BCB720F9F41B /* EventsTests.swift in Sources */,
-				BF_7B8DF357C9BBC41FAC46F705E504B8A3 /* MediaTypeTests.swift in Sources */,
-				BF_798DF057BBF3AABE9CA527736486DA11 /* XCTestManifests.swift in Sources */,
+				C91F77DBA9D7A5455DD17F14C5C18A58 /* Aria.swift in Sources */,
+				A7C98A58CF8B7710692FB2A3D16DBA14 /* Attributes.swift in Sources */,
+				1D5FBAD5A5389306A6E88211685AB401 /* ChildOf.swift in Sources */,
+				780C67A46BA9D2361F76C584529B4E16 /* DebugRender.swift in Sources */,
+				01A10D4EA430E797FFA31BFEB45627ED /* Elements.swift in Sources */,
+				45DF47B21461F09D2C0246DD8D995EF3 /* Events.swift in Sources */,
+				16533F003832605F81D5B2D7EC932B2F /* Html4.swift in Sources */,
+				04D70307F85F1E61E236EDC0AD42FE91 /* MediaType.swift in Sources */,
+				4A21B49606D1963916E5CB56B2E24F94 /* Node.swift in Sources */,
+				90E66630293805103BCF40AB6CAEC7F6 /* Render.swift in Sources */,
+				B5F6444A4BF392B405B7B2395C2D8CBB /* Tag.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_486634345880070F81FF70A14535A014 /* Sources */ = {
+		630338A7D1776A06167A0C971FF8260C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_884C6D4C6BA035CF95DACEBE216B76E2 /* HtmlSnapshotTestingTests.swift in Sources */,
-				BF_0EF35346B972BAAE87EF93DAE9A11501 /* XCTestManifests.swift in Sources */,
+				76F3F70426E382433C0B9C9309AB595E /* HtmlSnapshotTestingTests.swift in Sources */,
+				A54E5956BC01802D7679F586171E619E /* XCTestManifests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_76E5A454BAA5945F6970AF64320FD788 /* Sources */ = {
+		BD0797055DCB975FD9EA5BAE65D1E0D8 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_9A0B1A189B6074024418369D6B665DE3 /* Aria.swift in Sources */,
-				BF_61AB416E385994B572133AB831DA2AB3 /* Attributes.swift in Sources */,
-				BF_7A2DD0BACFFC06AA97C6FE9073DFA83F /* ChildOf.swift in Sources */,
-				BF_CE9BD77978ABBB3945304ED5FFDE4D22 /* DebugRender.swift in Sources */,
-				BF_C71D5072A7281A91A9B475DCE86C2B21 /* Elements.swift in Sources */,
-				BF_24441D3310AF85C4F376D600FF4C8958 /* Events.swift in Sources */,
-				BF_008A5702F99F07846B812AF73C8B45E1 /* Html4.swift in Sources */,
-				BF_347CC9F121F611817634BCED6EED5DC3 /* MediaType.swift in Sources */,
-				BF_8B22EC95C72808E7C4EB9655A38A0B5A /* Node.swift in Sources */,
-				BF_8362C1DC46756F8CBDFB9BB1345D9A93 /* Render.swift in Sources */,
-				BF_606F86A6C07CAA3721F9CB6EB65B3636 /* Tag.swift in Sources */,
+				50CD9F87EC29298AB3AF7DB95E1BF648 /* HtmlSnapshotTesting.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_8028A7936CB50E1A22E94C3DC34A1FE7 /* Sources */ = {
+		C58F7FD5230AD178954BB65CDC889C2B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_CCD2256A9DBC486987F3F43551B223A9 /* AriaTests.swift in Sources */,
-				BF_563D57FE0B16C29A91247EBEEE9EC7B0 /* AttributesTests.swift in Sources */,
-				BF_058AE1B1A3D7CFF10D12F6161A5BB5D5 /* ElementsTests.swift in Sources */,
-				BF_8B861E44FDF640569DE8FF05357D3A70 /* EventsTests.swift in Sources */,
-				BF_7DA986F804ABF0442B1896498E84A7A8 /* MediaTypeTests.swift in Sources */,
-				BF_FC2286DCB1EFFAF5878808FB40A6CDF0 /* XCTestManifests.swift in Sources */,
+				700952E0C833CD56069B1E9A82CBF072 /* HtmlSnapshotTesting.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_8B65B522274C0FC6C8C3436FB0CDF9A4 /* Sources */ = {
+		DAA9ED07754E89A1D9F2FD42FBBC7759 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_6AD9DAAD0E7665C0FAE92BCADE8F9E5B /* AriaTests.swift in Sources */,
-				BF_7B644F57B477753969E24089C336734C /* AttributesTests.swift in Sources */,
-				BF_8EB2DECBE7B14C281F77000FC19AAD0B /* ElementsTests.swift in Sources */,
-				BF_64E82553D6FE85AB9A9A0EC08ADD01ED /* EventsTests.swift in Sources */,
-				BF_4E262A2097369CAB0947E96FB0D20554 /* MediaTypeTests.swift in Sources */,
-				BF_9DE76F9CFD7CE49ECAB4FB4A5C8DE42D /* XCTestManifests.swift in Sources */,
+				2099BAB970D80BEC0B54849F169D1F82 /* HtmlSnapshotTestingTests.swift in Sources */,
+				AFE87284ABDA54DE2ABAC910039CA450 /* XCTestManifests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_A3115C515AF6943CB3FB42249EF1B84D /* Sources */ = {
+		DBB4B9616E2386CE9D5DC982651E5CB2 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_04EAFBA677DF1516B69B3E94C510B122 /* HtmlSnapshotTesting.swift in Sources */,
+				342033AF8BF6A1CAE8DAE52D05DC5D84 /* Aria.swift in Sources */,
+				121E7E9C359BC98E386560602A458F3A /* Attributes.swift in Sources */,
+				D803576621BCE4F021E29A85DFA974AE /* ChildOf.swift in Sources */,
+				943511A6917C0D324955E72640964FE9 /* DebugRender.swift in Sources */,
+				48B85DE1CC1FB6963E7B8B9F9CF3971C /* Elements.swift in Sources */,
+				21BC55C1164331DF516D6A29D32B0826 /* Events.swift in Sources */,
+				67DBA93187389C32312B03EC591CFC5B /* Html4.swift in Sources */,
+				2CF0C74814B7E7DEE5001BCB7E0B0465 /* MediaType.swift in Sources */,
+				232D4FCB46A640784F508A71A1B838B4 /* Node.swift in Sources */,
+				B720C142F7063B9B6F16078913D917B0 /* Render.swift in Sources */,
+				C4E4C2D595529DB466C13921E3BC14DF /* Tag.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_A9AE976A15137D14C488BEC51ECDBF90 /* Sources */ = {
+		E33F8653E7AC64501EAB9A33CD1CE86F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_F990810FF37D0B351B5B147A29A983C4 /* HtmlSnapshotTestingTests.swift in Sources */,
-				BF_9710C3C0101C3DAF8E7446DED2AB23B6 /* XCTestManifests.swift in Sources */,
+				9CC96B55188CC30804706A896AD85920 /* AriaTests.swift in Sources */,
+				1C810F7A3295BC0709C67CF5491DF03A /* AttributesTests.swift in Sources */,
+				C58132C4ABBB76F2954234280C6AB511 /* ElementsTests.swift in Sources */,
+				B2D1F981F0FDEACC1FF2C571D153A9B2 /* EventsTests.swift in Sources */,
+				C2F8882B4B3F347E3480C2811FC9C44A /* MediaTypeTests.swift in Sources */,
+				0E0A73032A028D9EE9E751B1FEFAF847 /* XCTestManifests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_B203030E5BF0C799FAEF12719C2CDCDE /* Sources */ = {
+		E8468F6DB380878420593ADF957BD754 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_6C8BBC64ECEFD8A269AF77E4BEDB870E /* HtmlSnapshotTestingTests.swift in Sources */,
-				BF_D6EFA4CEC590928E8746DAA42C8BE6E7 /* XCTestManifests.swift in Sources */,
+				A5E8D6FD70F957651D21573A306E7426 /* Aria.swift in Sources */,
+				87B59F892F691C9A4C47667811D19133 /* Attributes.swift in Sources */,
+				68D29CA1EC6653C73FF489391C239F85 /* ChildOf.swift in Sources */,
+				282FAD7E0F6982CF50D0F604079C8135 /* DebugRender.swift in Sources */,
+				45D9DE86DABC8B5B5BC3CA5F96E5C9F7 /* Elements.swift in Sources */,
+				DCB928080545ED169BBA87D8883AB8FB /* Events.swift in Sources */,
+				AEDDC90F978435848F8769AB9E57C021 /* Html4.swift in Sources */,
+				778780B4B83AEB8DE746BAB6B4A0A32A /* MediaType.swift in Sources */,
+				7EB5EC4C256933659B82A6FA8322B4FB /* Node.swift in Sources */,
+				8EFA74B726CDCB91161A1E6974BF3BC0 /* Render.swift in Sources */,
+				E48B4BC441FC140031399C59E9523494 /* Tag.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_BDBEA8231C20424E064DFB597FF52461 /* Sources */ = {
+		F71BFDDC67E75BBB8154F58EFB543078 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_EA15C26493DFD83A59AB9BE8E0D7AA4A /* AriaTests.swift in Sources */,
-				BF_8A354EAAB66D8E3DE255C128785F5C81 /* AttributesTests.swift in Sources */,
-				BF_F0C75B20B63A27C1EC68B41EB07496EB /* ElementsTests.swift in Sources */,
-				BF_5A573E2D0A8BAE09309A4785FDFF3D32 /* EventsTests.swift in Sources */,
-				BF_F3FA3DF870D54FB9B46B80B6B90FA204 /* MediaTypeTests.swift in Sources */,
-				BF_278F2A9F9C6DB1BB09F1B128BEA90554 /* XCTestManifests.swift in Sources */,
+				339017E55A0C394698EA8C9A13E376E5 /* AriaTests.swift in Sources */,
+				F69BED84D9CCA475C7569E5CCAEA580D /* AttributesTests.swift in Sources */,
+				519F8663ADF038097E7CB6998A8EEA00 /* ElementsTests.swift in Sources */,
+				ACB161F66536641251BB19DEBD37AFB7 /* EventsTests.swift in Sources */,
+				10CB995C346E4F6BB739245CF35BFD6C /* MediaTypeTests.swift in Sources */,
+				F374E58D4F1F115FE772AA42354E16CC /* XCTestManifests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_C66B6CCD8E3EA8559C1A36AE952A277E /* Sources */ = {
+		F7F9AFA0D7E961D4D57D2A2969DFA4DE /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_595D70987B019CFCD51444943CAE5C72 /* HtmlSnapshotTesting.swift in Sources */,
+				DDA36E7452BE4418B3427B6C398AA22D /* Aria.swift in Sources */,
+				0B3605A85BAE1007B25791B8083A399A /* Attributes.swift in Sources */,
+				0FD25ADBA170DC483E8414EAE4EAC895 /* ChildOf.swift in Sources */,
+				810FE3698DC4F588392CED75E74379F3 /* DebugRender.swift in Sources */,
+				8513AA929DA47348ED3F9A0DC62987D9 /* Elements.swift in Sources */,
+				79064327BF44307D2701787813E95EB1 /* Events.swift in Sources */,
+				E6A494B3721C07F9D64140D17A472FE5 /* Html4.swift in Sources */,
+				C0FD32A0ABF3F8F85B90E6D26C6BA156 /* MediaType.swift in Sources */,
+				D387E5D35A0C9F0E33610FF253829CBC /* Node.swift in Sources */,
+				0E374A295AE1B8D569BC10C41D6BAE75 /* Render.swift in Sources */,
+				E5A6BD4678FA157D7F40A9FDF00A72BE /* Tag.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_E1D26DE47F8EEA9DE0C71207A87F5144 /* Sources */ = {
+		FA3D6956ED335EE81F901EBC98E5B1EF /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_3B1027C6F72CA257FC500052522A4675 /* Aria.swift in Sources */,
-				BF_25F0CF956E6CE5A08CF04CC85E0A4295 /* Attributes.swift in Sources */,
-				BF_9FDEB02465B72227A53195875566C414 /* ChildOf.swift in Sources */,
-				BF_65F0E3E98B96408A9B918E11902CD2FD /* DebugRender.swift in Sources */,
-				BF_EDF30C936D87DB063C818C532B5BAF18 /* Elements.swift in Sources */,
-				BF_E37CBCFB5EB106C9B0B47D83BD00501B /* Events.swift in Sources */,
-				BF_9B72E8029CBB396C619144083CDEE8F5 /* Html4.swift in Sources */,
-				BF_AE4039F8D303A38511E101A94D136B23 /* MediaType.swift in Sources */,
-				BF_0617CDDDB48DE38770265BDD7CEB0DEC /* Node.swift in Sources */,
-				BF_867E037B341316E7D2ECE2571EEAED23 /* Render.swift in Sources */,
-				BF_281D2611AD316590D461069CDAD1A67C /* Tag.swift in Sources */,
+				1866BB4BEF6300372E372FD4D543C5E2 /* AriaTests.swift in Sources */,
+				D891E0698D5A9D1B852171D14C495EC5 /* AttributesTests.swift in Sources */,
+				B8A2EEB6FB193AE66A07C6ED862A347D /* ElementsTests.swift in Sources */,
+				4812E11C2178735574880DFBF7648F41 /* EventsTests.swift in Sources */,
+				42E5693ECA0E8F31F6D69A63F58F2FF9 /* MediaTypeTests.swift in Sources */,
+				73F75EC489DE8EB634388279CF2B24E0 /* XCTestManifests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		TD_2D2E8D0C8BA27FBFC8FAC0E588D034AE /* PBXTargetDependency */ = {
+		08B06CA02522562C0AAA711791676570 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_391C0E1A822D646F708827B001EB83D2 /* Html_iOS */;
-			targetProxy = CIP_FD6FA1F02F1A1056267C6CC6ABD3BC79 /* PBXContainerItemProxy */;
+			target = 875B8C7FB1A8896A28D7B853F513CFD6 /* Html_tvOS */;
+			targetProxy = B5858D39C442D31EDFF46EBCF4082E03 /* PBXContainerItemProxy */;
 		};
-		TD_3D83B190D0212792CDFDDA92671C94AF /* PBXTargetDependency */ = {
+		096DC36E3B64481A20755245060DB29B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_3DAB1392843626D3536CA19914B502C8 /* Html_macOS */;
-			targetProxy = CIP_8DF159F48FA6256DEFC4C32AEBD165C6 /* PBXContainerItemProxy */;
+			target = 875B8C7FB1A8896A28D7B853F513CFD6 /* Html_tvOS */;
+			targetProxy = 4B300CBD2D7222D89A2D78871D93E8D0 /* PBXContainerItemProxy */;
 		};
-		TD_5E1A3F9667CA86E021E68F13E2F22782 /* PBXTargetDependency */ = {
+		110288077A8ABC1833459AA18BA8EC6D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_E3DC39F33A9CC5CE33CBED0C7A0716AB /* Html_tvOS */;
-			targetProxy = CIP_5E11A82DA491889A8D1375324A3CFCA8 /* PBXContainerItemProxy */;
+			target = 387DD84FD9EB67768EA91AEA30999728 /* Html_macOS */;
+			targetProxy = 0BF8AA2AB0F08B5CDB439089887CE326 /* PBXContainerItemProxy */;
 		};
-		TD_806B692C992C010CFFF126117B2E0E05 /* PBXTargetDependency */ = {
+		1735ED5D490B44E819CB1F92C9B378F4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_A56629B8583F524D8DABDEB1B3B5FCB8 /* Html_watchOS */;
-			targetProxy = CIP_ED65AA7D2A04B134645AC114BE634B38 /* PBXContainerItemProxy */;
+			target = 2BA1D0CC8309950F649BDD13CBCDE39B /* HtmlSnapshotTesting_tvOS */;
+			targetProxy = 79A3189C141EEEE59F8E0A813AB24575 /* PBXContainerItemProxy */;
 		};
-		TD_A8D1AB9B9D218884B7DEA066200142E4 /* PBXTargetDependency */ = {
+		486F5CB76FB61F3395056F95714F007A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_391C0E1A822D646F708827B001EB83D2 /* Html_iOS */;
-			targetProxy = CIP_825D966EF836E0E71CF6881A75269FA8 /* PBXContainerItemProxy */;
+			target = F810FEAA71B0586D1B6CE7F412FF7D3E /* Html_iOS */;
+			targetProxy = 70611457C4A3A4E01EF124FF77B81AAC /* PBXContainerItemProxy */;
 		};
-		TD_C0C3B9066E9270D13A89F7D4C20CB09E /* PBXTargetDependency */ = {
+		66EED7EC4D65FE5BE48E9F0026BA717C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_5881CD49A13FAFE4B62A050F5942B296 /* HtmlSnapshotTesting_iOS */;
-			targetProxy = CIP_89EDC2A7F6D7562F8EF940B46BAA6DBA /* PBXContainerItemProxy */;
+			target = 387DD84FD9EB67768EA91AEA30999728 /* Html_macOS */;
+			targetProxy = 42AB772B2F24E967596BE368C8F28BEC /* PBXContainerItemProxy */;
 		};
-		TD_CB8FE0FEB7D30203E7807BF9E99CBF37 /* PBXTargetDependency */ = {
+		79E57862C51E2B55B0EC5D60CAD07151 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_8DA0D6B0D3FB381C06CED88C8D8EB1F3 /* HtmlSnapshotTesting_tvOS */;
-			targetProxy = CIP_FEC3F08F65BDD69FD4ED10630D2DA027 /* PBXContainerItemProxy */;
+			target = F810FEAA71B0586D1B6CE7F412FF7D3E /* Html_iOS */;
+			targetProxy = 6FECA1441A0146880FF034B00A469E96 /* PBXContainerItemProxy */;
 		};
-		TD_DCE99D0564E79A0C1CB788A94337CCD0 /* PBXTargetDependency */ = {
+		8ED14E7F682D100C424BC56EC920EC87 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_E3DC39F33A9CC5CE33CBED0C7A0716AB /* Html_tvOS */;
-			targetProxy = CIP_DA359FC6B1376BF6D720448BF666D52C /* PBXContainerItemProxy */;
+			target = ECF3589FFC8B598E275967EA4DCE9E99 /* Html_watchOS */;
+			targetProxy = 928BB69B1A4CE587A6E451C15AAEDEBF /* PBXContainerItemProxy */;
 		};
-		TD_E602C0A4C47944650BECE537C914501F /* PBXTargetDependency */ = {
+		C649DCC9019B845AE101C9473E5D62D4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_3DAB1392843626D3536CA19914B502C8 /* Html_macOS */;
-			targetProxy = CIP_428162E099AAE498F66071D85657F7DD /* PBXContainerItemProxy */;
+			target = 9D4E25C5088CA6D3CA55EC77E0EDCA7D /* HtmlSnapshotTesting_macOS */;
+			targetProxy = 82C2DC31F5C7E40CD7373615416F1D1B /* PBXContainerItemProxy */;
 		};
-		TD_F7539E2170D052FD165B3CC230B5158A /* PBXTargetDependency */ = {
+		D3C289FC62F3195C67F426E168E932DC /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_35F4D7F166DB6BD11B0FE52D126BA796 /* HtmlSnapshotTesting_macOS */;
-			targetProxy = CIP_3F002AD65FB7CBF51126C49E45500E71 /* PBXContainerItemProxy */;
+			target = 83770D5D7E5A47BE568F39AD0B92F45D /* HtmlSnapshotTesting_iOS */;
+			targetProxy = A97507570D2BD13B832930E5D3620D17 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		BC_06DE2DAE0876989F3C0488B1CB0CB566 /* Debug */ = {
+		011943896C56AEABFE2BF8AF40D1C782 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlSnapshotTestingTests-tvOS";
+				PRODUCT_NAME = HtmlSnapshotTestingTests;
+				SDKROOT = appletvos;
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = Release;
+		};
+		29BC73C35D0EE49DA404BF000F6A10E0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\".\"",
+				);
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlSnapshotTesting-tvOS";
+				PRODUCT_NAME = HtmlSnapshotTesting;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		2D665AA397718E800B44AFEF45B3A478 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlTests-tvOS";
+				PRODUCT_NAME = HtmlTests;
+				SDKROOT = appletvos;
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = Debug;
+		};
+		3649321727B6F0771F1B6C189B5BEEC0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\".\"",
+				);
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlSnapshotTesting-iOS";
+				PRODUCT_NAME = HtmlSnapshotTesting;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		36CBC073A1675C51EC2B664DAAAE7B45 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlSnapshotTestingTests-tvOS";
+				PRODUCT_NAME = HtmlSnapshotTestingTests;
+				SDKROOT = appletvos;
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = Debug;
+		};
+		3F1FB63DC871D0A61D49BAE0A7271EC0 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -1001,19 +1087,7 @@
 			};
 			name = Debug;
 		};
-		BC_0A3A17AA6DB74D83AA4F88F39E525D88 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlTests-iOS";
-				PRODUCT_NAME = HtmlTests;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		BC_206415F1EA7AC68A380B7E00494C1223 /* Debug */ = {
+		4F05B9611FC531624AC49D3A97D63AA8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
@@ -1034,121 +1108,7 @@
 			};
 			name = Debug;
 		};
-		BC_258D71B113BB889A6F0C320CD092467F /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlSnapshotTestingTests-tvOS";
-				PRODUCT_NAME = HtmlSnapshotTestingTests;
-				SDKROOT = appletvos;
-				TARGETED_DEVICE_FAMILY = 3;
-			};
-			name = Debug;
-		};
-		BC_2817927ED502C84B38368D2EC6B5EF32 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlTests-tvOS";
-				PRODUCT_NAME = HtmlTests;
-				SDKROOT = appletvos;
-				TARGETED_DEVICE_FAMILY = 3;
-			};
-			name = Debug;
-		};
-		BC_28DF056C13A829EC3AAD2032ADF68436 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlSnapshotTestingTests-tvOS";
-				PRODUCT_NAME = HtmlSnapshotTestingTests;
-				SDKROOT = appletvos;
-				TARGETED_DEVICE_FAMILY = 3;
-			};
-			name = Release;
-		};
-		BC_31DD439987248714EB8BB8C206A27EA9 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"\".\"",
-				);
-				INFOPLIST_FILE = Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlSnapshotTesting-macOS";
-				PRODUCT_NAME = HtmlSnapshotTesting;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = Debug;
-		};
-		BC_39241E7D98C62F1B3F9CA941C2CBCDCA /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.Html-macOS";
-				PRODUCT_NAME = Html;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = Debug;
-		};
-		BC_4218F41AE9912BC20AC6C66FE88BEF80 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlTests-tvOS";
-				PRODUCT_NAME = HtmlTests;
-				SDKROOT = appletvos;
-				TARGETED_DEVICE_FAMILY = 3;
-			};
-			name = Release;
-		};
-		BC_51BC7B6E7EFABF8A0307524FD56AD5A1 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.Html-watchOS";
-				PRODUCT_NAME = Html;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = Debug;
-		};
-		BC_59DCA11BD298677A2C364B7091616443 /* Release */ = {
+		560B6974B40E65FD2A750D5DCAF8510C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
@@ -1167,59 +1127,112 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
-			name = Release;
+			name = Debug;
 		};
-		BC_5D82526E135020393ADB819F6560D512 /* Release */ = {
+		5866BC7842FEEF9983A1298407673B07 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.2;
-				VALIDATE_PRODUCT = YES;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.Html-tvOS";
+				PRODUCT_NAME = Html;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;
 		};
-		BC_687D208815014A217D210337BD703586 /* Release */ = {
+		5CAC8C8C3F615D5A7244A0396E82D217 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\".\"",
+				);
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlSnapshotTesting-tvOS";
+				PRODUCT_NAME = HtmlSnapshotTesting;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		61FEB00EEE0C215D06880ED757EFC3E0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlTests-tvOS";
+				PRODUCT_NAME = HtmlTests;
+				SDKROOT = appletvos;
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = Release;
+		};
+		77B44A09D564A3C74E3994DA5B223240 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlTests-watchOS";
+				PRODUCT_NAME = HtmlTests;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = Debug;
+		};
+		7FAC8F306A182CF35F57C6AD2500B3DB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlSnapshotTestingTests-iOS";
+				PRODUCT_NAME = HtmlSnapshotTestingTests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		80553A9CED70EAFBF4958BFA86BF73F1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.Html-watchOS";
+				PRODUCT_NAME = Html;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		8D1D902CD8EC14A4DA46B365B993176B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
@@ -1242,21 +1255,21 @@
 				SKIP_INSTALL = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
-			name = Release;
+			name = Debug;
 		};
-		BC_6FFEDC49E6F0FCB2EA8AAA0BBAF3D946 /* Release */ = {
+		979D074AB420372E0F43F578C1BCDCF3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				COMBINE_HIDPI_IMAGES = YES;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlTests-macOS";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlTests-iOS";
 				PRODUCT_NAME = HtmlTests;
-				SDKROOT = macosx;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
-			name = Release;
+			name = Debug;
 		};
-		BC_7082599EC9F1924DAF3C2E6907240B87 /* Debug */ = {
+		A3F705CF3B79C48FFE493A1394F28DDC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -1268,7 +1281,7 @@
 			};
 			name = Debug;
 		};
-		BC_7E9F4DECB71DE8CC14B16B33F42E05EC /* Debug */ = {
+		A4FDA207D34DEB872B5F399D38B69FA2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1326,32 +1339,48 @@
 			};
 			name = Debug;
 		};
-		BC_8DBDB943848CADE7BCE6B045552D8133 /* Release */ = {
+		A542C4FCC8BC3D74FA01DD609F97950C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlTests-watchOS";
-				PRODUCT_NAME = HtmlTests;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.Html-iOS";
+				PRODUCT_NAME = Html;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		A60C4CD8C2D1FC18D0A6E57766B6ACFB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.Html-watchOS";
+				PRODUCT_NAME = Html;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
 			};
-			name = Release;
+			name = Debug;
 		};
-		BC_91D8FD23F33A7E3D1F032328B069AF91 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				COMBINE_HIDPI_IMAGES = YES;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlSnapshotTestingTests-macOS";
-				PRODUCT_NAME = HtmlSnapshotTestingTests;
-				SDKROOT = macosx;
-			};
-			name = Release;
-		};
-		BC_9BCAC3DEFD5026C798EA1A60FFC169DE /* Release */ = {
+		AB4849E23293F39FAD173616B0E511A1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
@@ -1374,12 +1403,25 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
+			name = Debug;
+		};
+		B327519364056902C568A11A922D39EA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlTests-iOS";
+				PRODUCT_NAME = HtmlTests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
 			name = Release;
 		};
-		BC_9C34A53DEFE1DF0A68D267627509181A /* Debug */ = {
+		C38731DCF5B8D8B4491157DBDFDD8A7A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1387,62 +1429,29 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.Html-iOS";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.Html-macOS";
 				PRODUCT_NAME = Html;
-				SDKROOT = iphoneos;
+				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
 		};
-		BC_9E249D61F2A94E31D75A209985723A5F /* Release */ = {
+		D0A45C0403FBD9E4416B0F5D4E8F2683 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.Html-watchOS";
-				PRODUCT_NAME = Html;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlTests-watchOS";
+				PRODUCT_NAME = HtmlTests;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 4;
-				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;
 		};
-		BC_9F5FCACFE0B7B633426B8597A819280B /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"\".\"",
-				);
-				INFOPLIST_FILE = Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlSnapshotTesting-tvOS";
-				PRODUCT_NAME = HtmlSnapshotTesting;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 3;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = Debug;
-		};
-		BC_B4AF93FC0F3F4AD627A2BFA37DF45866 /* Release */ = {
+		D7B0848393FB37DF01D6D9E1F56E2018 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
@@ -1463,20 +1472,82 @@
 			};
 			name = Release;
 		};
-		BC_BCCD5862D6C8896706C9005D7770B1DB /* Debug */ = {
+		DF6BE307B3E19D1ECF8F731448C20E19 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlTests-watchOS";
-				PRODUCT_NAME = HtmlTests;
-				SDKROOT = watchos;
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\".\"",
+				);
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlSnapshotTesting-macOS";
+				PRODUCT_NAME = HtmlSnapshotTesting;
+				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
 			};
-			name = Debug;
+			name = Release;
 		};
-		BC_C922D44FDBF98AC6A544965CE48737CA /* Debug */ = {
+		EB3D8F15DBB42369CC38C2D5E9700260 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.2;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		F17A6E1B1B5A0561D12C0784615E4A82 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -1488,240 +1559,169 @@
 			};
 			name = Debug;
 		};
-		BC_CD07538898FE4B9361E8B7E7A041C279 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"\".\"",
-				);
-				INFOPLIST_FILE = Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlSnapshotTesting-tvOS";
-				PRODUCT_NAME = HtmlSnapshotTesting;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 3;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = Release;
-		};
-		BC_CD1AC9686145A4058C479D7EB25FAC39 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"\".\"",
-				);
-				INFOPLIST_FILE = Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlSnapshotTesting-iOS";
-				PRODUCT_NAME = HtmlSnapshotTesting;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = Debug;
-		};
-		BC_CD91EA9C18FF7AAA09B0B76A427B05E6 /* Release */ = {
+		F1BA90C1B5B8E7CEA0D241ECD424FF86 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlSnapshotTestingTests-iOS";
-				PRODUCT_NAME = HtmlSnapshotTestingTests;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Release;
-		};
-		BC_D7C8C3DFC45ADCC00EDD6185D1AC3B2B /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlTests-iOS";
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlTests-macOS";
 				PRODUCT_NAME = HtmlTests;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
-		BC_E34712B7075D6BB9AC2238F1A639D5B1 /* Release */ = {
+		FD53EE69A10D91828BCAFB7BE0A5F556 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.Html-tvOS";
-				PRODUCT_NAME = Html;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 3;
-				VERSIONING_SYSTEM = "apple-generic";
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.pointfree.HtmlSnapshotTestingTests-macOS";
+				PRODUCT_NAME = HtmlSnapshotTestingTests;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		CL_035E70787F58B7A45E9C0CA167594798 /* Build configuration list for PBXNativeTarget "HtmlTests_tvOS" */ = {
+		00429DAA9AA8FF808E618D2C67850C2D /* Build configuration list for PBXNativeTarget "HtmlSnapshotTestingTests_macOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_2817927ED502C84B38368D2EC6B5EF32 /* Debug */,
-				BC_4218F41AE9912BC20AC6C66FE88BEF80 /* Release */,
+				F17A6E1B1B5A0561D12C0784615E4A82 /* Debug */,
+				FD53EE69A10D91828BCAFB7BE0A5F556 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_07248284D902B7D116DF9C8019E8BD7B /* Build configuration list for PBXNativeTarget "HtmlTests_watchOS" */ = {
+		02CFF7F8DCCEC1A27465872E5109FAD3 /* Build configuration list for PBXNativeTarget "HtmlSnapshotTesting_iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_BCCD5862D6C8896706C9005D7770B1DB /* Debug */,
-				BC_8DBDB943848CADE7BCE6B045552D8133 /* Release */,
+				AB4849E23293F39FAD173616B0E511A1 /* Debug */,
+				3649321727B6F0771F1B6C189B5BEEC0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_1CD299291AE0BFFA37367999CEB6F900 /* Build configuration list for PBXNativeTarget "Html_tvOS" */ = {
+		09327A61B6F3295CFE5674279D1955FC /* Build configuration list for PBXProject "Html" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_206415F1EA7AC68A380B7E00494C1223 /* Debug */,
-				BC_E34712B7075D6BB9AC2238F1A639D5B1 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_22C0E5C81ECB635472569EFFEA8319DA /* Build configuration list for PBXNativeTarget "HtmlTests_macOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_06DE2DAE0876989F3C0488B1CB0CB566 /* Debug */,
-				BC_6FFEDC49E6F0FCB2EA8AAA0BBAF3D946 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_2AAD18E374F68D92C2AF3F10876697CF /* Build configuration list for PBXNativeTarget "HtmlTests_iOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_0A3A17AA6DB74D83AA4F88F39E525D88 /* Debug */,
-				BC_D7C8C3DFC45ADCC00EDD6185D1AC3B2B /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_36D42AC3DE4FF6C0C91AA27CB7BED96F /* Build configuration list for PBXNativeTarget "Html_watchOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_51BC7B6E7EFABF8A0307524FD56AD5A1 /* Debug */,
-				BC_9E249D61F2A94E31D75A209985723A5F /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_728CA9104A9BA70AFD0D66631D9B25E2 /* Build configuration list for PBXProject "Html" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_7E9F4DECB71DE8CC14B16B33F42E05EC /* Debug */,
-				BC_5D82526E135020393ADB819F6560D512 /* Release */,
+				A4FDA207D34DEB872B5F399D38B69FA2 /* Debug */,
+				EB3D8F15DBB42369CC38C2D5E9700260 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		CL_905577B2B1F7F177BEA37911480E6682 /* Build configuration list for PBXNativeTarget "HtmlSnapshotTestingTests_macOS" */ = {
+		1D3FFC21A2629F546BB403453C20481B /* Build configuration list for PBXNativeTarget "HtmlTests_watchOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_C922D44FDBF98AC6A544965CE48737CA /* Debug */,
-				BC_91D8FD23F33A7E3D1F032328B069AF91 /* Release */,
+				77B44A09D564A3C74E3994DA5B223240 /* Debug */,
+				D0A45C0403FBD9E4416B0F5D4E8F2683 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_945B5094C88A155540D2897E5A7EA6EC /* Build configuration list for PBXNativeTarget "HtmlSnapshotTesting_iOS" */ = {
+		205C554E125845FED588DF6CD8D273ED /* Build configuration list for PBXNativeTarget "HtmlSnapshotTestingTests_tvOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_CD1AC9686145A4058C479D7EB25FAC39 /* Debug */,
-				BC_9BCAC3DEFD5026C798EA1A60FFC169DE /* Release */,
+				36CBC073A1675C51EC2B664DAAAE7B45 /* Debug */,
+				011943896C56AEABFE2BF8AF40D1C782 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_A4FAD437AF76FDBA9E3C49D474751D14 /* Build configuration list for PBXNativeTarget "Html_iOS" */ = {
+		34356219C5D498565F2E29C6AD1A10F8 /* Build configuration list for PBXNativeTarget "HtmlTests_tvOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_9C34A53DEFE1DF0A68D267627509181A /* Debug */,
-				BC_59DCA11BD298677A2C364B7091616443 /* Release */,
+				2D665AA397718E800B44AFEF45B3A478 /* Debug */,
+				61FEB00EEE0C215D06880ED757EFC3E0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_A5BF7EDA76AE6BC08855C7AC43201B90 /* Build configuration list for PBXNativeTarget "Html_macOS" */ = {
+		4375A851BEE667A5BE8463A368490AA3 /* Build configuration list for PBXNativeTarget "HtmlSnapshotTestingTests_iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_39241E7D98C62F1B3F9CA941C2CBCDCA /* Debug */,
-				BC_B4AF93FC0F3F4AD627A2BFA37DF45866 /* Release */,
+				A3F705CF3B79C48FFE493A1394F28DDC /* Debug */,
+				7FAC8F306A182CF35F57C6AD2500B3DB /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_D6C7C63AF6E329A40C69B9B62FBBCB36 /* Build configuration list for PBXNativeTarget "HtmlSnapshotTesting_macOS" */ = {
+		7361D4AFE8C29EE405C39A6ECC7D4C81 /* Build configuration list for PBXNativeTarget "Html_macOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_31DD439987248714EB8BB8C206A27EA9 /* Debug */,
-				BC_687D208815014A217D210337BD703586 /* Release */,
+				C38731DCF5B8D8B4491157DBDFDD8A7A /* Debug */,
+				D7B0848393FB37DF01D6D9E1F56E2018 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_D99A9344C8A0D2283BC48B784B8AB7F5 /* Build configuration list for PBXNativeTarget "HtmlSnapshotTestingTests_tvOS" */ = {
+		74A6985BA841A6B69A009881679995BD /* Build configuration list for PBXNativeTarget "Html_tvOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_258D71B113BB889A6F0C320CD092467F /* Debug */,
-				BC_28DF056C13A829EC3AAD2032ADF68436 /* Release */,
+				4F05B9611FC531624AC49D3A97D63AA8 /* Debug */,
+				5866BC7842FEEF9983A1298407673B07 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_E03EA63DE9CCFC9DEB988DC5AFBAFE8B /* Build configuration list for PBXNativeTarget "HtmlSnapshotTestingTests_iOS" */ = {
+		7B27AF6FECA51D0A3D4993DD5D2EC94D /* Build configuration list for PBXNativeTarget "Html_watchOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_7082599EC9F1924DAF3C2E6907240B87 /* Debug */,
-				BC_CD91EA9C18FF7AAA09B0B76A427B05E6 /* Release */,
+				A60C4CD8C2D1FC18D0A6E57766B6ACFB /* Debug */,
+				80553A9CED70EAFBF4958BFA86BF73F1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_FEE21409DFDDCFEB1780816ECBFD3E12 /* Build configuration list for PBXNativeTarget "HtmlSnapshotTesting_tvOS" */ = {
+		9DDE14C3A0616AD73B6D3127882BB161 /* Build configuration list for PBXNativeTarget "Html_iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_9F5FCACFE0B7B633426B8597A819280B /* Debug */,
-				BC_CD07538898FE4B9361E8B7E7A041C279 /* Release */,
+				560B6974B40E65FD2A750D5DCAF8510C /* Debug */,
+				A542C4FCC8BC3D74FA01DD609F97950C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		C2A2AA3B6C1FE18F4E5F56B9C2733E72 /* Build configuration list for PBXNativeTarget "HtmlTests_iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				979D074AB420372E0F43F578C1BCDCF3 /* Debug */,
+				B327519364056902C568A11A922D39EA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		CBC7217548F04660792C50F0638E8D9D /* Build configuration list for PBXNativeTarget "HtmlSnapshotTesting_tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				29BC73C35D0EE49DA404BF000F6A10E0 /* Debug */,
+				5CAC8C8C3F615D5A7244A0396E82D217 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		DE53FB1A8938E18AF7785B4971EF5C05 /* Build configuration list for PBXNativeTarget "HtmlSnapshotTesting_macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8D1D902CD8EC14A4DA46B365B993176B /* Debug */,
+				DF6BE307B3E19D1ECF8F731448C20E19 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		F27C702E5A3143E744B5E29F2851DEE3 /* Build configuration list for PBXNativeTarget "HtmlTests_macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3F1FB63DC871D0A61D49BAE0A7271EC0 /* Debug */,
+				F1BA90C1B5B8E7CEA0D241ECD424FF86 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = P_71156FC3BAF7CC8140053AE66992A365 /* Project object */;
+	rootObject = CFEA2F996BC045811F1828EEFB911A38 /* Project object */;
 }

--- a/Html.xcodeproj/xcshareddata/xcschemes/HtmlSnapshotTesting_iOS.xcscheme
+++ b/Html.xcodeproj/xcshareddata/xcschemes/HtmlSnapshotTesting_iOS.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_5881CD49A13FAFE4B62A050F5942B296"
+               BlueprintIdentifier = "83770D5D7E5A47BE568F39AD0B92F45D"
                BuildableName = "HtmlSnapshotTesting.framework"
                BlueprintName = "HtmlSnapshotTesting_iOS"
                ReferencedContainer = "container:Html.xcodeproj">
@@ -32,7 +32,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_2DC28C2207FB2259D050202830AD64D1"
+               BlueprintIdentifier = "6A73DBC9B9DB85707C2C0821F55D62C4"
                BuildableName = "HtmlSnapshotTestingTests.xctest"
                BlueprintName = "HtmlSnapshotTestingTests_iOS"
                ReferencedContainer = "container:Html.xcodeproj">
@@ -42,7 +42,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_5881CD49A13FAFE4B62A050F5942B296"
+            BlueprintIdentifier = "83770D5D7E5A47BE568F39AD0B92F45D"
             BuildableName = "HtmlSnapshotTesting.framework"
             BlueprintName = "HtmlSnapshotTesting_iOS"
             ReferencedContainer = "container:Html.xcodeproj">
@@ -66,7 +66,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_5881CD49A13FAFE4B62A050F5942B296"
+            BlueprintIdentifier = "83770D5D7E5A47BE568F39AD0B92F45D"
             BuildableName = "HtmlSnapshotTesting.framework"
             BlueprintName = "HtmlSnapshotTesting_iOS"
             ReferencedContainer = "container:Html.xcodeproj">
@@ -87,7 +87,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_5881CD49A13FAFE4B62A050F5942B296"
+            BlueprintIdentifier = "83770D5D7E5A47BE568F39AD0B92F45D"
             BuildableName = "HtmlSnapshotTesting.framework"
             BlueprintName = "HtmlSnapshotTesting_iOS"
             ReferencedContainer = "container:Html.xcodeproj">

--- a/Html.xcodeproj/xcshareddata/xcschemes/HtmlSnapshotTesting_macOS.xcscheme
+++ b/Html.xcodeproj/xcshareddata/xcschemes/HtmlSnapshotTesting_macOS.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_35F4D7F166DB6BD11B0FE52D126BA796"
+               BlueprintIdentifier = "9D4E25C5088CA6D3CA55EC77E0EDCA7D"
                BuildableName = "HtmlSnapshotTesting.framework"
                BlueprintName = "HtmlSnapshotTesting_macOS"
                ReferencedContainer = "container:Html.xcodeproj">
@@ -32,7 +32,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_2AB5827BD5D16BFB6725C893076C6FDF"
+               BlueprintIdentifier = "10893907EC7EE4BFA378F918CAC99DFE"
                BuildableName = "HtmlSnapshotTestingTests.xctest"
                BlueprintName = "HtmlSnapshotTestingTests_macOS"
                ReferencedContainer = "container:Html.xcodeproj">
@@ -42,7 +42,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_35F4D7F166DB6BD11B0FE52D126BA796"
+            BlueprintIdentifier = "9D4E25C5088CA6D3CA55EC77E0EDCA7D"
             BuildableName = "HtmlSnapshotTesting.framework"
             BlueprintName = "HtmlSnapshotTesting_macOS"
             ReferencedContainer = "container:Html.xcodeproj">
@@ -66,7 +66,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_35F4D7F166DB6BD11B0FE52D126BA796"
+            BlueprintIdentifier = "9D4E25C5088CA6D3CA55EC77E0EDCA7D"
             BuildableName = "HtmlSnapshotTesting.framework"
             BlueprintName = "HtmlSnapshotTesting_macOS"
             ReferencedContainer = "container:Html.xcodeproj">
@@ -87,7 +87,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_35F4D7F166DB6BD11B0FE52D126BA796"
+            BlueprintIdentifier = "9D4E25C5088CA6D3CA55EC77E0EDCA7D"
             BuildableName = "HtmlSnapshotTesting.framework"
             BlueprintName = "HtmlSnapshotTesting_macOS"
             ReferencedContainer = "container:Html.xcodeproj">

--- a/Html.xcodeproj/xcshareddata/xcschemes/HtmlSnapshotTesting_tvOS.xcscheme
+++ b/Html.xcodeproj/xcshareddata/xcschemes/HtmlSnapshotTesting_tvOS.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_8DA0D6B0D3FB381C06CED88C8D8EB1F3"
+               BlueprintIdentifier = "2BA1D0CC8309950F649BDD13CBCDE39B"
                BuildableName = "HtmlSnapshotTesting.framework"
                BlueprintName = "HtmlSnapshotTesting_tvOS"
                ReferencedContainer = "container:Html.xcodeproj">
@@ -32,7 +32,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_DD09D77AEA211941B06E7B13605F9DF1"
+               BlueprintIdentifier = "D66EE4CDA1674BC198B4235AA4485515"
                BuildableName = "HtmlSnapshotTestingTests.xctest"
                BlueprintName = "HtmlSnapshotTestingTests_tvOS"
                ReferencedContainer = "container:Html.xcodeproj">
@@ -42,7 +42,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_8DA0D6B0D3FB381C06CED88C8D8EB1F3"
+            BlueprintIdentifier = "2BA1D0CC8309950F649BDD13CBCDE39B"
             BuildableName = "HtmlSnapshotTesting.framework"
             BlueprintName = "HtmlSnapshotTesting_tvOS"
             ReferencedContainer = "container:Html.xcodeproj">
@@ -66,7 +66,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_8DA0D6B0D3FB381C06CED88C8D8EB1F3"
+            BlueprintIdentifier = "2BA1D0CC8309950F649BDD13CBCDE39B"
             BuildableName = "HtmlSnapshotTesting.framework"
             BlueprintName = "HtmlSnapshotTesting_tvOS"
             ReferencedContainer = "container:Html.xcodeproj">
@@ -87,7 +87,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_8DA0D6B0D3FB381C06CED88C8D8EB1F3"
+            BlueprintIdentifier = "2BA1D0CC8309950F649BDD13CBCDE39B"
             BuildableName = "HtmlSnapshotTesting.framework"
             BlueprintName = "HtmlSnapshotTesting_tvOS"
             ReferencedContainer = "container:Html.xcodeproj">

--- a/Html.xcodeproj/xcshareddata/xcschemes/Html_iOS.xcscheme
+++ b/Html.xcodeproj/xcshareddata/xcschemes/Html_iOS.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_391C0E1A822D646F708827B001EB83D2"
+               BlueprintIdentifier = "F810FEAA71B0586D1B6CE7F412FF7D3E"
                BuildableName = "Html.framework"
                BlueprintName = "Html_iOS"
                ReferencedContainer = "container:Html.xcodeproj">
@@ -32,7 +32,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_C8AB64528B429FF8C5E983E839B1E0BE"
+               BlueprintIdentifier = "B641E0069847CD6E1B6AC66EFDFE23AC"
                BuildableName = "HtmlTests.xctest"
                BlueprintName = "HtmlTests_iOS"
                ReferencedContainer = "container:Html.xcodeproj">
@@ -42,7 +42,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_391C0E1A822D646F708827B001EB83D2"
+            BlueprintIdentifier = "F810FEAA71B0586D1B6CE7F412FF7D3E"
             BuildableName = "Html.framework"
             BlueprintName = "Html_iOS"
             ReferencedContainer = "container:Html.xcodeproj">
@@ -66,7 +66,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_391C0E1A822D646F708827B001EB83D2"
+            BlueprintIdentifier = "F810FEAA71B0586D1B6CE7F412FF7D3E"
             BuildableName = "Html.framework"
             BlueprintName = "Html_iOS"
             ReferencedContainer = "container:Html.xcodeproj">
@@ -87,7 +87,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_391C0E1A822D646F708827B001EB83D2"
+            BlueprintIdentifier = "F810FEAA71B0586D1B6CE7F412FF7D3E"
             BuildableName = "Html.framework"
             BlueprintName = "Html_iOS"
             ReferencedContainer = "container:Html.xcodeproj">

--- a/Html.xcodeproj/xcshareddata/xcschemes/Html_macOS.xcscheme
+++ b/Html.xcodeproj/xcshareddata/xcschemes/Html_macOS.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_3DAB1392843626D3536CA19914B502C8"
+               BlueprintIdentifier = "387DD84FD9EB67768EA91AEA30999728"
                BuildableName = "Html.framework"
                BlueprintName = "Html_macOS"
                ReferencedContainer = "container:Html.xcodeproj">
@@ -32,7 +32,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_0EC5D5A0415352CD656BDFBBA012F05F"
+               BlueprintIdentifier = "C9276D931EC24AE11A4283A3A36DFE84"
                BuildableName = "HtmlTests.xctest"
                BlueprintName = "HtmlTests_macOS"
                ReferencedContainer = "container:Html.xcodeproj">
@@ -42,7 +42,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_3DAB1392843626D3536CA19914B502C8"
+            BlueprintIdentifier = "387DD84FD9EB67768EA91AEA30999728"
             BuildableName = "Html.framework"
             BlueprintName = "Html_macOS"
             ReferencedContainer = "container:Html.xcodeproj">
@@ -66,7 +66,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_3DAB1392843626D3536CA19914B502C8"
+            BlueprintIdentifier = "387DD84FD9EB67768EA91AEA30999728"
             BuildableName = "Html.framework"
             BlueprintName = "Html_macOS"
             ReferencedContainer = "container:Html.xcodeproj">
@@ -87,7 +87,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_3DAB1392843626D3536CA19914B502C8"
+            BlueprintIdentifier = "387DD84FD9EB67768EA91AEA30999728"
             BuildableName = "Html.framework"
             BlueprintName = "Html_macOS"
             ReferencedContainer = "container:Html.xcodeproj">

--- a/Html.xcodeproj/xcshareddata/xcschemes/Html_tvOS.xcscheme
+++ b/Html.xcodeproj/xcshareddata/xcschemes/Html_tvOS.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_E3DC39F33A9CC5CE33CBED0C7A0716AB"
+               BlueprintIdentifier = "875B8C7FB1A8896A28D7B853F513CFD6"
                BuildableName = "Html.framework"
                BlueprintName = "Html_tvOS"
                ReferencedContainer = "container:Html.xcodeproj">
@@ -32,7 +32,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_E3FE8A7E649940DA2207FA60E84BE68D"
+               BlueprintIdentifier = "39FAF90AB05CB37935D4204A5BE017B8"
                BuildableName = "HtmlTests.xctest"
                BlueprintName = "HtmlTests_tvOS"
                ReferencedContainer = "container:Html.xcodeproj">
@@ -42,7 +42,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_E3DC39F33A9CC5CE33CBED0C7A0716AB"
+            BlueprintIdentifier = "875B8C7FB1A8896A28D7B853F513CFD6"
             BuildableName = "Html.framework"
             BlueprintName = "Html_tvOS"
             ReferencedContainer = "container:Html.xcodeproj">
@@ -66,7 +66,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_E3DC39F33A9CC5CE33CBED0C7A0716AB"
+            BlueprintIdentifier = "875B8C7FB1A8896A28D7B853F513CFD6"
             BuildableName = "Html.framework"
             BlueprintName = "Html_tvOS"
             ReferencedContainer = "container:Html.xcodeproj">
@@ -87,7 +87,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_E3DC39F33A9CC5CE33CBED0C7A0716AB"
+            BlueprintIdentifier = "875B8C7FB1A8896A28D7B853F513CFD6"
             BuildableName = "Html.framework"
             BlueprintName = "Html_tvOS"
             ReferencedContainer = "container:Html.xcodeproj">

--- a/Html.xcodeproj/xcshareddata/xcschemes/Html_watchOS.xcscheme
+++ b/Html.xcodeproj/xcshareddata/xcschemes/Html_watchOS.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_A56629B8583F524D8DABDEB1B3B5FCB8"
+               BlueprintIdentifier = "ECF3589FFC8B598E275967EA4DCE9E99"
                BuildableName = "Html.framework"
                BlueprintName = "Html_watchOS"
                ReferencedContainer = "container:Html.xcodeproj">
@@ -32,7 +32,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_FA846A49F72C052E4C6D4EB6DDB7C485"
+               BlueprintIdentifier = "774558CB50D4BB2B0629975BADF641CA"
                BuildableName = "HtmlTests.xctest"
                BlueprintName = "HtmlTests_watchOS"
                ReferencedContainer = "container:Html.xcodeproj">
@@ -42,7 +42,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_A56629B8583F524D8DABDEB1B3B5FCB8"
+            BlueprintIdentifier = "ECF3589FFC8B598E275967EA4DCE9E99"
             BuildableName = "Html.framework"
             BlueprintName = "Html_watchOS"
             ReferencedContainer = "container:Html.xcodeproj">
@@ -66,7 +66,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_A56629B8583F524D8DABDEB1B3B5FCB8"
+            BlueprintIdentifier = "ECF3589FFC8B598E275967EA4DCE9E99"
             BuildableName = "Html.framework"
             BlueprintName = "Html_watchOS"
             ReferencedContainer = "container:Html.xcodeproj">
@@ -87,7 +87,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_A56629B8583F524D8DABDEB1B3B5FCB8"
+            BlueprintIdentifier = "ECF3589FFC8B598E275967EA4DCE9E99"
             BuildableName = "Html.framework"
             BlueprintName = "Html_watchOS"
             ReferencedContainer = "container:Html.xcodeproj">

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,7 @@ carthage:
 	carthage update --no-build --use-submodules
 
 xcodeproj:
-	@command -v xcodegen >/dev/null 2>&1 || { echo >&2 "Required tool missing: XcodeGen. Try 'brew install xcodegen' perhaps?"; exit 1; }
-	xcodegen
+	swift run xcodegen
 
 test-linux:
 	docker build --tag html . \

--- a/Package.swift
+++ b/Package.swift
@@ -13,9 +13,8 @@ let package = Package(
       targets: ["HtmlSnapshotTesting"]),
   ],
   dependencies: [
-    .package(
-      url: "https://github.com/pointfreeco/swift-snapshot-testing.git",
-      from: "1.1.0"),
+    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.1.0"),
+    .package(url: "https://github.com/yonaskolb/XcodeGen.git", from: "2.2.0"),
   ],
   targets: [
     .target(


### PR DESCRIPTION
Let's make `xcodegen` a dev dependency so that we can deterministically build the Xcode project.

Doing this in prep for reviewing #46 