### PR TITLE
Support the "accept" attribute for file inputs

### DIFF
--- a/Sources/Html/Attributes.swift
+++ b/Sources/Html/Attributes.swift
@@ -598,14 +598,14 @@ extension Attribute where Element == Tag.Input {
     return .init("type", value.rawValue)
   }
 
-	/// Pattern or file types to be selected (only for type="file")
-	///
-	/// - Parameter value:
-	/// 	The file extension or media type the user can select,
-	///   such as ".pdf" or "image/*"
-	public static func accept(_ value: String...) -> Attribute {
-		return .init("accept", value.joined(separator: ", "))
-	}
+  /// Pattern or file types to be selected (only for type="file")
+  ///
+  /// - Parameter value:
+  /// 	The file extension or media type the user can select,
+  ///   such as ".pdf" or "image/*"
+  public static func accept(_ value: String...) -> Attribute {
+    return .init("accept", value.joined(separator: ", "))
+  }
 }
 
 extension Attribute where Element == Tag.Meta {

--- a/Sources/Html/Attributes.swift
+++ b/Sources/Html/Attributes.swift
@@ -572,6 +572,27 @@ public enum InputType: String {
   case week
 }
 
+public struct Accept: RawRepresentable {
+  public let rawValue: String
+
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  public static let audio = Accept(rawValue: "audio/*")
+  public static let image = Accept(rawValue: "image/*")
+  public static let video = Accept(rawValue: "video/*")
+
+  public static func file(_ type: String) -> Accept {
+    return .init(rawValue: type.hasPrefix(".") ? type : "." + type)
+  }
+
+  public static func mime(_ type: MediaType) -> Accept {
+    let mimeTypeOnly = type.description.split(separator: ";")[0]
+    return .init(rawValue: String(mimeTypeOnly))
+  }
+}
+
 extension Attribute where Element == Tag.Input {
   /// Whether the command or control is checked.
   ///
@@ -603,8 +624,8 @@ extension Attribute where Element == Tag.Input {
   /// - Parameter value:
   /// 	The file extension or media type the user can select,
   ///   such as ".pdf" or "image/*"
-  public static func accept(_ value: String...) -> Attribute {
-    return .init("accept", value.joined(separator: ", "))
+  public static func accept(_ value: Accept...) -> Attribute {
+    return .init("accept", value.map { $0.rawValue }.joined(separator: ", "))
   }
 }
 

--- a/Sources/Html/Attributes.swift
+++ b/Sources/Html/Attributes.swift
@@ -597,6 +597,15 @@ extension Attribute where Element == Tag.Input {
   public static func type(_ value: InputType) -> Attribute {
     return .init("type", value.rawValue)
   }
+
+	/// Pattern or file types to be selected (only for type="file")
+	///
+	/// - Parameter value:
+	/// 	The file extension or media type the user can select,
+	///   such as ".pdf" or "image/*"
+	public static func accept(_ value: String...) -> Attribute {
+		return .init("accept", value.joined(separator: ", "))
+	}
 }
 
 extension Attribute where Element == Tag.Meta {

--- a/Tests/HtmlTests/AttributesTests.swift
+++ b/Tests/HtmlTests/AttributesTests.swift
@@ -110,8 +110,8 @@ final class AttributesTests: XCTestCase {
     )
     XCTAssertEqual(
       """
-			<input type="file" required accept=".pdf, image/*">
-			"""
+      <input type="file" required accept=".pdf, image/*">
+      """
       , render(.input(attributes: [.type(.file), .required(true), .accept(".pdf", "image/*")])))
 
     XCTAssertEqual(
@@ -317,20 +317,23 @@ final class AttributesTests: XCTestCase {
     XCTAssertEqual("<a draggable=\"false\"></a>", render(.a(attributes: [.draggable(false)])))
     XCTAssertEqual("<a></a>", render(.a(attributes: [.draggable(.auto)])))
 
-    XCTAssertEqual("""
+    XCTAssertEqual(
+      """
       <form enctype=\"application/x-www-form-urlencoded\"></form>
       """,
-                   render(.form(attributes: [.enctype(.applicationXWwwFormUrlencoded)]))
+      render(.form(attributes: [.enctype(.applicationXWwwFormUrlencoded)]))
     )
-    XCTAssertEqual("""
+    XCTAssertEqual(
+      """
       <form enctype=\"multipart/form-data\"></form>
       """,
-                   render(.form(attributes: [.enctype(.multipartFormData)]))
+      render(.form(attributes: [.enctype(.multipartFormData)]))
     )
-    XCTAssertEqual("""
+    XCTAssertEqual(
+      """
       <form enctype=\"text/plain\"></form>
       """,
-                   render(.form(attributes: [.enctype(.textPlain)]))
+      render(.form(attributes: [.enctype(.textPlain)]))
     )
 
     XCTAssertEqual(

--- a/Tests/HtmlTests/AttributesTests.swift
+++ b/Tests/HtmlTests/AttributesTests.swift
@@ -108,6 +108,11 @@ final class AttributesTests: XCTestCase {
       """,
       render(.input(attributes: [.autofocus(false), .checked(false), .disabled(false), .readonly(false), .required(false)]))
     )
+		XCTAssertEqual(
+			"""
+			<input type="file" required accept=".pdf, image/*">
+			"""
+			, render(.input(attributes: [.type(.file), .required(true), .accept(".pdf", "image/*")])))
 
     XCTAssertEqual(
       """

--- a/Tests/HtmlTests/AttributesTests.swift
+++ b/Tests/HtmlTests/AttributesTests.swift
@@ -112,7 +112,14 @@ final class AttributesTests: XCTestCase {
       """
       <input type="file" required accept=".pdf, image/*">
       """,
-      render(.input(attributes: [.type(.file), .required(true), .accept(".pdf", "image/*")])))
+      render(.input(attributes: [.type(.file), .required(true), .accept(.file("pdf"), .image)]))
+    )
+    XCTAssertEqual(
+      """
+      <input type="file" accept="application/javascript, text/html, .css">
+      """,
+      render(.input(attributes: [.type(.file), .accept(.mime(.javascript), .mime(.html), .file(".css"))]))
+    )
 
     XCTAssertEqual(
       """

--- a/Tests/HtmlTests/AttributesTests.swift
+++ b/Tests/HtmlTests/AttributesTests.swift
@@ -111,8 +111,8 @@ final class AttributesTests: XCTestCase {
     XCTAssertEqual(
       """
       <input type="file" required accept=".pdf, image/*">
-      """
-      , render(.input(attributes: [.type(.file), .required(true), .accept(".pdf", "image/*")])))
+      """,
+      render(.input(attributes: [.type(.file), .required(true), .accept(".pdf", "image/*")])))
 
     XCTAssertEqual(
       """

--- a/Tests/HtmlTests/AttributesTests.swift
+++ b/Tests/HtmlTests/AttributesTests.swift
@@ -108,11 +108,11 @@ final class AttributesTests: XCTestCase {
       """,
       render(.input(attributes: [.autofocus(false), .checked(false), .disabled(false), .readonly(false), .required(false)]))
     )
-		XCTAssertEqual(
-			"""
+    XCTAssertEqual(
+      """
 			<input type="file" required accept=".pdf, image/*">
 			"""
-			, render(.input(attributes: [.type(.file), .required(true), .accept(".pdf", "image/*")])))
+      , render(.input(attributes: [.type(.file), .required(true), .accept(".pdf", "image/*")])))
 
     XCTAssertEqual(
       """
@@ -320,17 +320,17 @@ final class AttributesTests: XCTestCase {
     XCTAssertEqual("""
       <form enctype=\"application/x-www-form-urlencoded\"></form>
       """,
-      render(.form(attributes: [.enctype(.applicationXWwwFormUrlencoded)]))
+                   render(.form(attributes: [.enctype(.applicationXWwwFormUrlencoded)]))
     )
     XCTAssertEqual("""
       <form enctype=\"multipart/form-data\"></form>
       """,
-      render(.form(attributes: [.enctype(.multipartFormData)]))
+                   render(.form(attributes: [.enctype(.multipartFormData)]))
     )
     XCTAssertEqual("""
       <form enctype=\"text/plain\"></form>
       """,
-      render(.form(attributes: [.enctype(.textPlain)]))
+                   render(.form(attributes: [.enctype(.textPlain)]))
     )
 
     XCTAssertEqual(


### PR DESCRIPTION
Adds support for the `accept` attribute of file upload tags (`<input type="file>`).

```swift
Node.input(attributes: [.type(.file), .accept(".pdf", "image/*")]))
```

Will render as:

```html
<input type="file" accept=".pdf, image/*">
```

See also [Mozilla's documentation](mozilla)

[mozilla]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept