### PR TITLE
Sort srcset dictionary on render.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ test-ios: xcodeproj
 
 test-swift:
 	swift test \
-		--enable-pubgrub-resolver \
 		--enable-test-discovery \
 		--parallel
 

--- a/Sources/Html/Attributes.swift
+++ b/Sources/Html/Attributes.swift
@@ -1400,7 +1400,10 @@ extension Attribute where Element: HasSrcset {
   ///
   /// - Parameter value: Images to use in different situations (e.g., high-resolution displays, small monitors, etc).
   public static func srcset(_ value: [String: Size]) -> Attribute {
-    return .init("srcset", value.map { url, size in url + " " + size.description }.joined(separator: ", "))
+    /// Sort by size, to aid tests with consistent output
+    return .init("srcset", value
+                  .sorted { $0.value.description > $1.value.description }
+                  .map { url, size in url + " " + size.description }.joined(separator: ", "))
   }
 }
 

--- a/Sources/Html/Attributes.swift
+++ b/Sources/Html/Attributes.swift
@@ -1402,7 +1402,7 @@ extension Attribute where Element: HasSrcset {
   public static func srcset(_ value: [String: Size]) -> Attribute {
     /// Sort by size, to aid tests with consistent output
     return .init("srcset", value
-                  .sorted { $0.value.description > $1.value.description }
+                  .sorted { $0.key < $1.key }
                   .map { url, size in url + " " + size.description }.joined(separator: ", "))
   }
 }

--- a/Tests/HtmlTests/AttributesTests.swift
+++ b/Tests/HtmlTests/AttributesTests.swift
@@ -47,6 +47,18 @@ final class AttributesTests: XCTestCase {
       """,
       render(.img(attributes: [.crossorigin(.useCredentials)]))
     )
+    XCTAssertEqual(
+      """
+      <img src="src1" srcset="src3 3x, src2 2x, src1 1x" height="42" width="43">
+      """,
+      render(.img(attributes: [.src("src1"), .srcset(["src3": .x(3), "src2": .x(2), "src1": .x(1)]), .height(42), .width(43)]))
+    )
+    XCTAssertEqual(
+      """
+      <img src="src1" srcset="src2 84w, src1 42w, src3 126w" height="42" width="43">
+      """,
+      render(.img(attributes: [.src("src1"), .srcset(["src1": .w(42), "src2": .w(84), "src3": .w(126)]), .height(42), .width(43)]))
+    )
 
     XCTAssertEqual(
       """

--- a/Tests/HtmlTests/AttributesTests.swift
+++ b/Tests/HtmlTests/AttributesTests.swift
@@ -49,13 +49,13 @@ final class AttributesTests: XCTestCase {
     )
     XCTAssertEqual(
       """
-      <img src="src1" srcset="src3 3x, src2 2x, src1 1x" height="42" width="43">
+      <img src="src1" srcset="src1 1x, src2 2x, src3 3x" height="42" width="43">
       """,
       render(.img(attributes: [.src("src1"), .srcset(["src3": .x(3), "src2": .x(2), "src1": .x(1)]), .height(42), .width(43)]))
     )
     XCTAssertEqual(
       """
-      <img src="src1" srcset="src2 84w, src1 42w, src3 126w" height="42" width="43">
+      <img src="src1" srcset="src1 42w, src2 84w, src3 126w" height="42" width="43">
       """,
       render(.img(attributes: [.src("src1"), .srcset(["src1": .w(42), "src2": .w(84), "src3": .w(126)]), .height(42), .width(43)]))
     )


### PR DESCRIPTION
HTML doesn't care what order the srcset alternatives are in,
but sorting (by anything consistent) improves testability.

It does alpha sort on size.description - this will calc
the description more times than is ideal, but the dict sizes
are always going to be small enough that this makes no difference
in practice.