### PR TITLE
Fix swift 6 concurrency issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ test-linux:
 		--rm \
 		-v "$(PWD):$(PWD)" \
 		-w "$(PWD)" \
-		swift:5.7-focal \
+		swift:6.0-focal \
 		bash -c 'swift test'
 
 test-macos: xcodeproj

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,16 +1,24 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "swift-snapshot-testing",
-        "repositoryURL": "https://github.com/pointfreeco/swift-snapshot-testing.git",
-        "state": {
-          "branch": null,
-          "revision": "cef5b3f6f11781dd4591bdd1dd0a3d22bd609334",
-          "version": "1.11.0"
-        }
+  "originHash" : "c2217f3a9bfb04515bca941987fb8e52aa0d2033cd77f82c6ff0f91a868fe948",
+  "pins" : [
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
+      "state" : {
+        "revision" : "7b0bbbae90c41f848f90ac7b4df6c4f50068256d",
+        "version" : "1.17.5"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
+      }
+    }
+  ],
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version: 5.5
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
       targets: ["HtmlSnapshotTesting"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.11.0")
+    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.11.1")
   ],
   targets: [
     .target(

--- a/Sources/Html/Attributes.swift
+++ b/Sources/Html/Attributes.swift
@@ -468,7 +468,7 @@ extension Attribute where Element == Tag.Form {
     return .init("action", value)
   }
 
-  public struct Enctype: RawRepresentable {
+  public struct Enctype: RawRepresentable, Sendable {
     public let rawValue: String
 
     public init(rawValue: String) {
@@ -575,7 +575,7 @@ public enum InputType: String {
   case week
 }
 
-public struct Accept: RawRepresentable {
+public struct Accept: RawRepresentable, Sendable {
   public let rawValue: String
 
   public init(rawValue: String) {

--- a/Sources/Html/DebugRender.swift
+++ b/Sources/Html/DebugRender.swift
@@ -1,4 +1,4 @@
-public struct Config {
+public struct Config: Sendable {
   public let indentation: String
   public let newline: String
 

--- a/Sources/Html/MediaType.swift
+++ b/Sources/Html/MediaType.swift
@@ -1,4 +1,4 @@
-public enum MediaType: CustomStringConvertible {
+public enum MediaType: CustomStringConvertible, Sendable {
   case application(Application)
   case audio(Audio)
   case font(Font)
@@ -54,7 +54,7 @@ public enum MediaType: CustomStringConvertible {
   }
 }
 
-public struct Application: RawRepresentable {
+public struct Application: RawRepresentable, Sendable {
   public let rawValue: String
 
   public init(rawValue: String) {
@@ -67,7 +67,7 @@ public struct Application: RawRepresentable {
   public static let xWwwFormUrlencoded = Application(rawValue: "x-www-form-url-encoded")
 }
 
-public struct Audio: RawRepresentable {
+public struct Audio: RawRepresentable, Sendable {
   public let rawValue: String
 
   public init(rawValue: String) {
@@ -80,7 +80,7 @@ public struct Audio: RawRepresentable {
   public static let wav = Audio(rawValue: "wav")
 }
 
-public struct Font: RawRepresentable {
+public struct Font: RawRepresentable, Sendable {
   public let rawValue: String
 
   public init(rawValue: String) {
@@ -95,7 +95,7 @@ public struct Font: RawRepresentable {
   public static let woff2 = Audio(rawValue: "woff2")
 }
 
-public struct Image: RawRepresentable {
+public struct Image: RawRepresentable, Sendable {
   public let rawValue: String
 
   public init(rawValue: String) {
@@ -110,7 +110,7 @@ public struct Image: RawRepresentable {
   public static let tiff = Image(rawValue: "tiff")
 }
 
-public struct Multipart: RawRepresentable {
+public struct Multipart: RawRepresentable, Sendable {
   public let rawValue: String
 
   public init(rawValue: String) {
@@ -124,7 +124,7 @@ public struct Multipart: RawRepresentable {
   public static let formData = Multipart(rawValue: "form-data")
 }
 
-public struct Text: RawRepresentable {
+public struct Text: RawRepresentable, Sendable {
   public let rawValue: String
 
   public init(rawValue: String) {
@@ -137,7 +137,7 @@ public struct Text: RawRepresentable {
   public static let plain = Text(rawValue: "plain")
 }
 
-public struct Video: RawRepresentable {
+public struct Video: RawRepresentable, Sendable {
   public let rawValue: String
 
   public init(rawValue: String) {
@@ -149,7 +149,7 @@ public struct Video: RawRepresentable {
   public static let webm = Video(rawValue: "webm")
 }
 
-public struct Charset: RawRepresentable {
+public struct Charset: RawRepresentable, Sendable {
   public let rawValue: String
 
   public init(rawValue: String) {

--- a/Sources/Html/Node.swift
+++ b/Sources/Html/Node.swift
@@ -1,5 +1,5 @@
 /// The basic unit of an HTML tree.
-public enum Node {
+public enum Node: Sendable {
   /// Represents a renderable comment.
   case comment(String)
 

--- a/Sources/HtmlSnapshotTesting/HtmlSnapshotTesting.swift
+++ b/Sources/HtmlSnapshotTesting/HtmlSnapshotTesting.swift
@@ -1,5 +1,5 @@
 import Html
-import SnapshotTesting
+@preconcurrency import SnapshotTesting
 
 extension Snapshotting where Value == [Node], Format == String {
   public static var html: Snapshotting {

--- a/Tests/HtmlSnapshotTestingTests/HtmlSnapshotTestingTests.swift
+++ b/Tests/HtmlSnapshotTestingTests/HtmlSnapshotTestingTests.swift
@@ -496,7 +496,7 @@ final class SnapshotTestingTests: XCTestCase {
       )
     )
 
-    assertSnapshot(matching: doc, as: .html)
+    assertSnapshot(of: doc, as: .html)
   }
 
   func testSnapshots() {
@@ -642,6 +642,6 @@ final class SnapshotTestingTests: XCTestCase {
       .video(.track(src: "track1"), transparent: "Fallback"),
     ]
 
-    assertSnapshot(matching: doc, as: .html)
+    assertSnapshot(of: doc, as: .html)
   }
 }


### PR DESCRIPTION
- Conform Node to Sendable
- fix swift-tools-version declaration (it was complaining that a space is needed after `:`)
- Update minimum swift-snapshot-testing from `1.11.0` to `1.11.1` to fix xcode issues